### PR TITLE
chore: Update dependencies for docs site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+ - Updated dependencies in docs site (no breaking changes)
+
 ## [0.3.0] - 2024-08-08
 
 ### Added

--- a/docs/blog/2024-06-24-its-me-morio/index.md
+++ b/docs/blog/2024-06-24-its-me-morio/index.md
@@ -8,7 +8,7 @@ Today we are delighted to introduce [Morio](https://github.com/certeu/morio),
 an end-to-end streaming data backbone designed to meet your observability
 needs. Morio will simplify the setup and management of a robust observability
 infrastructure, leveraging top-tier open-source technologies.
-
+<!-- truncate -->
 Morio is currently **early-access alpha code**. We are building this in the
 open, so feel free to look around, try it out, and [leave
 feedback](https://github.com/certeu/morio/discussions).

--- a/docs/blog/2024-06-26-oven-window/index.md
+++ b/docs/blog/2024-06-26-oven-window/index.md
@@ -7,7 +7,7 @@ tags: [morio, disclaimer, alpha]
 After the initial months of design, preparation, and writing code, we've
 recently started working on the Morio documentation, including its automated
 publishing in a CI pipeline.
-
+<!-- truncate -->
 We strongly believe that documentation should never be an afterthought, but be
 written alongside the code itself. When trying to explain things in
 documentation, those things that are counter-intuitive and awkwardly named

--- a/docs/blog/2024-08-01-clustering-support/index.md
+++ b/docs/blog/2024-08-01-clustering-support/index.md
@@ -7,7 +7,7 @@ tags: [morio, cluster, alpha]
 We are happy to report that initial support for distributed Morio deployments
 [has been merged into the codebase](https://github.com/certeu/morio/pull/18).
 In other words, deploying a highly avaiable Morio cluster is now possible.
-
+<!-- truncate -->
 There are certainly still some sharp edges — and probably a bunch of bugs too
 — but the groundword for clustered deployments is in place.
 

--- a/docs/blog/2024-08-08-v0.3.0/index.md
+++ b/docs/blog/2024-08-08-v0.3.0/index.md
@@ -5,7 +5,7 @@ tags: [morio, release, alpha, v0.3.0]
 ---
 
 We have released verion 0.3.0 of Morio, which brings initial clustering support.
-
+<!-- truncate -->
 We [wrote about the new support for clustered
 deployments](/blog/2024/08/01/clustering-support) last week, and it's the main
 feature in this release. Check [the

--- a/docs/blog/authors.yml
+++ b/docs/blog/authors.yml
@@ -3,6 +3,9 @@ jdecock:
   title: Morio Maintainer
   url: https://github.com/joostdecock
   image_url: https://github.com/joostdecock.png
+  socials:
+    github: joostdecock
+    Mastodon: https://freesewing.social/@joost
 
 stellene:
   name: Serge Tellene

--- a/docs/blog/authors.yml
+++ b/docs/blog/authors.yml
@@ -3,6 +3,8 @@ jdecock:
   title: Morio Maintainer
   url: https://github.com/joostdecock
   image_url: https://github.com/joostdecock.png
+  description: Full-stack engineer at CERT-EU. Creator of Morio. More plans than time.
+  page: true
   socials:
     github: joostdecock
     Mastodon: https://freesewing.social/@joost

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -23,6 +23,10 @@ const config = {
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
 
+  // Blog
+  onInlineAuthors: 'throw',
+  onUntruncatedBlogPost: 'throw'
+
   // i18n
   i18n: {
     defaultLocale: 'en',

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -89,7 +89,7 @@ const config = {
       image: 'img/morio-social-card.jpg',
       announcementBar: {
         content:
-          '<b>Warning</b>: Morio is not yet ready for production | <a href="/blog/2024/05/15/oven-window">Learn more</a>',
+          '<b>Warning</b>: Morio is not yet ready for production | <a href="/blog/2024/06/26/oven-window">Learn more</a>',
         isCloseable: false,
         backgroundColor: '#EB6534',
         textColor: '#fff',

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,20 +16,20 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "3.3.2",
-    "@docusaurus/preset-classic": "3.3.2",
-    "@docusaurus/theme-mermaid": "^3.3.2",
-    "@mdx-js/react": "^3.0.0",
-    "clsx": "^2.0.0",
-    "prism-react-renderer": "^2.3.0",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
-    "redocusaurus": "^2.1.1",
-    "remark-smartypants": "^3.0.1"
+    "@docusaurus/core": "3.5.1",
+    "@docusaurus/preset-classic": "3.5.1",
+    "@docusaurus/theme-mermaid": "3.5.1",
+    "@mdx-js/react": "3.0.1",
+    "clsx": "2.1.1",
+    "prism-react-renderer": "2.3.1",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "redocusaurus": "2.1.1",
+    "remark-smartypants": "3.0.2"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.3.2",
-    "@docusaurus/types": "3.3.2"
+    "@docusaurus/module-type-aliases": "3.5.1",
+    "@docusaurus/types": "3.5.1"
   },
   "browserslist": {
     "production": [

--- a/docs/static/oas-api.yaml
+++ b/docs/static/oas-api.yaml
@@ -21,7 +21,7 @@ info:
     name: EUPL
     url: >-
       https://joinup.ec.europa.eu/collection/eupl/eupl-guidelines-faq-infographics
-  version: 0.2.0
+  version: 0.3.0
   x-logo:
     url: /downloads/morio-card-embed.svg
     backgroundColor: transparent

--- a/docs/static/oas-core.yaml
+++ b/docs/static/oas-core.yaml
@@ -39,7 +39,7 @@ info:
     name: EUPL
     url: >-
       https://joinup.ec.europa.eu/collection/eupl/eupl-guidelines-faq-infographics
-  version: 0.2.0
+  version: 0.3.0
   x-logo:
     url: /downloads/morio-card-embed.svg
     backgroundColor: transparent

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "morio",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "morio",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "EUPL",
       "workspaces": [
         "api",
@@ -17,9 +17,6 @@
         "shared",
         "ui"
       ],
-      "dependencies": {
-        "pino-pretty": "^11.2.2"
-      },
       "devDependencies": {
         "esbuild": "^0.20.2",
         "eslint": "^8.56.0",
@@ -28,12 +25,16 @@
         "husky": "^9.0.11",
         "lint-staged": "^15.2.2",
         "nodemon": "^3.1.0",
+        "pino-pretty": "^11.2.2",
         "prettier": "^3.2.5"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "api": {
       "name": "@morio/api",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "EUPL",
       "dependencies": {
         "@otplib/preset-default": "^12.0.1",
@@ -56,8 +57,7 @@
         "passport-ldapauth": "^3.0.1",
         "pino": "^8.20.0",
         "qrcode": "^1.5.3",
-        "redoc-express": "^2.1.0",
-        "swagger-ui-express": "^5.0.0"
+        "redoc-express": "^2.1.0"
       },
       "devDependencies": {
         "esbuild": "^0.20.2"
@@ -85,7 +85,7 @@
     },
     "config": {
       "name": "@morio/config",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "bson": "^6.2.0",
@@ -95,7 +95,7 @@
     },
     "core": {
       "name": "@morio/core",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "EUPL",
       "dependencies": {
         "axios": "^1.6.8",
@@ -104,6 +104,7 @@
         "express": "^4.19.2",
         "glob": "^10.3.12",
         "joi": "^17.12.3",
+        "joi-to-swagger": "^6.2.0",
         "js-yaml": "^4.1.0",
         "jsonwebtoken": "^9.0.2",
         "lodash.get": "^4.4.2",
@@ -112,7 +113,8 @@
         "mustache": "^4.2.0",
         "node-forge": "^1.3.1",
         "node-jose": "^2.2.0",
-        "pino": "^8.20.0"
+        "pino": "^8.20.0",
+        "redoc-express": "^2.1.0"
       },
       "devDependencies": {
         "esbuild": "^0.20.2"
@@ -141,20 +143,20 @@
     "docs": {
       "version": "0.0.0",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/preset-classic": "3.3.2",
-        "@docusaurus/theme-mermaid": "^3.3.2",
-        "@mdx-js/react": "^3.0.0",
-        "clsx": "^2.0.0",
-        "prism-react-renderer": "^2.3.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0",
-        "redocusaurus": "^2.1.1",
-        "remark-smartypants": "^3.0.1"
+        "@docusaurus/core": "3.5.1",
+        "@docusaurus/preset-classic": "3.5.1",
+        "@docusaurus/theme-mermaid": "3.5.1",
+        "@mdx-js/react": "3.0.1",
+        "clsx": "2.1.1",
+        "prism-react-renderer": "2.3.1",
+        "react": "18.3.1",
+        "react-dom": "18.3.1",
+        "redocusaurus": "2.1.1",
+        "remark-smartypants": "3.0.2"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "3.3.2",
-        "@docusaurus/types": "3.3.2"
+        "@docusaurus/module-type-aliases": "3.5.1",
+        "@docusaurus/types": "3.5.1"
       },
       "engines": {
         "node": ">=18.0"
@@ -198,9 +200,10 @@
       }
     },
     "docs/node_modules/remark-smartypants": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.1.tgz",
-      "integrity": "sha512-qyshfCl2eLO0i0558e79ZJsfojC5wjnYLByjt0FmjJQN6aYwcRxpoj784LZJSoWCdnA2ubh5rLNGb8Uur/wDng==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.2.tgz",
+      "integrity": "sha512-ILTWeOriIluwEvPjv67v7Blgrcx+LZOkAUVtKI3putuhlZm84FnqDORNXPPm+HY3NdZOMhyDwZ1E+eZB/Df5dA==",
+      "license": "MIT",
       "dependencies": {
         "retext": "^9.0.0",
         "retext-smartypants": "^6.0.0",
@@ -303,6 +306,8 @@
     },
     "node_modules/@algolia/autocomplete-core": {
       "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz",
+      "integrity": "sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-plugin-algolia-insights": "1.9.3",
@@ -311,6 +316,8 @@
     },
     "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
       "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.3.tgz",
+      "integrity": "sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-shared": "1.9.3"
@@ -321,6 +328,8 @@
     },
     "node_modules/@algolia/autocomplete-preset-algolia": {
       "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.9.3.tgz",
+      "integrity": "sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-shared": "1.9.3"
@@ -332,6 +341,8 @@
     },
     "node_modules/@algolia/autocomplete-shared": {
       "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.3.tgz",
+      "integrity": "sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==",
       "license": "MIT",
       "peerDependencies": {
         "@algolia/client-search": ">= 4.9.1 < 6",
@@ -339,125 +350,157 @@
       }
     },
     "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.23.3",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.24.0.tgz",
+      "integrity": "sha512-t63W9BnoXVrGy9iYHBgObNXqYXM3tYXCjDSHeNwnsc324r4o5UiVKUiAB4THQ5z9U5hTj6qUvwg/Ez43ZD85ww==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/cache-common": "4.23.3"
+        "@algolia/cache-common": "4.24.0"
       }
     },
     "node_modules/@algolia/cache-common": {
-      "version": "4.23.3",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.24.0.tgz",
+      "integrity": "sha512-emi+v+DmVLpMGhp0V9q9h5CdkURsNmFC+cOS6uK9ndeJm9J4TiqSvPYVu+THUP8P/S08rxf5x2P+p3CfID0Y4g==",
       "license": "MIT"
     },
     "node_modules/@algolia/cache-in-memory": {
-      "version": "4.23.3",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.24.0.tgz",
+      "integrity": "sha512-gDrt2so19jW26jY3/MkFg5mEypFIPbPoXsQGQWAi6TrCPsNOSEYepBMPlucqWigsmEy/prp5ug2jy/N3PVG/8w==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/cache-common": "4.23.3"
+        "@algolia/cache-common": "4.24.0"
       }
     },
     "node_modules/@algolia/client-account": {
-      "version": "4.23.3",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.24.0.tgz",
+      "integrity": "sha512-adcvyJ3KjPZFDybxlqnf+5KgxJtBjwTPTeyG2aOyoJvx0Y8dUQAEOEVOJ/GBxX0WWNbmaSrhDURMhc+QeevDsA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "4.23.3",
-        "@algolia/client-search": "4.23.3",
-        "@algolia/transporter": "4.23.3"
+        "@algolia/client-common": "4.24.0",
+        "@algolia/client-search": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.23.3",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.24.0.tgz",
+      "integrity": "sha512-y8jOZt1OjwWU4N2qr8G4AxXAzaa8DBvyHTWlHzX/7Me1LX8OayfgHexqrsL4vSBcoMmVw2XnVW9MhL+Y2ZDJXg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "4.23.3",
-        "@algolia/client-search": "4.23.3",
-        "@algolia/requester-common": "4.23.3",
-        "@algolia/transporter": "4.23.3"
+        "@algolia/client-common": "4.24.0",
+        "@algolia/client-search": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "4.23.3",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+      "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/requester-common": "4.23.3",
-        "@algolia/transporter": "4.23.3"
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.23.3",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.24.0.tgz",
+      "integrity": "sha512-l5FRFm/yngztweU0HdUzz1rC4yoWCFo3IF+dVIVTfEPg906eZg5BOd1k0K6rZx5JzyyoP4LdmOikfkfGsKVE9w==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "4.23.3",
-        "@algolia/requester-common": "4.23.3",
-        "@algolia/transporter": "4.23.3"
+        "@algolia/client-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "4.23.3",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
+      "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "4.23.3",
-        "@algolia/requester-common": "4.23.3",
-        "@algolia/transporter": "4.23.3"
+        "@algolia/client-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/@algolia/events": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@algolia/events/-/events-4.0.1.tgz",
+      "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ==",
       "license": "MIT"
     },
     "node_modules/@algolia/logger-common": {
-      "version": "4.23.3",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.24.0.tgz",
+      "integrity": "sha512-LLUNjkahj9KtKYrQhFKCzMx0BY3RnNP4FEtO+sBybCjJ73E8jNdaKJ/Dd8A/VA4imVHP5tADZ8pn5B8Ga/wTMA==",
       "license": "MIT"
     },
     "node_modules/@algolia/logger-console": {
-      "version": "4.23.3",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.24.0.tgz",
+      "integrity": "sha512-X4C8IoHgHfiUROfoRCV+lzSy+LHMgkoEEU1BbKcsfnV0i0S20zyy0NLww9dwVHUWNfPPxdMU+/wKmLGYf96yTg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/logger-common": "4.23.3"
+        "@algolia/logger-common": "4.24.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "4.23.3",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-4.24.0.tgz",
+      "integrity": "sha512-P9kcgerfVBpfYHDfVZDvvdJv0lEoCvzNlOy2nykyt5bK8TyieYyiD0lguIJdRZZYGre03WIAFf14pgE+V+IBlw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.23.3",
-        "@algolia/cache-common": "4.23.3",
-        "@algolia/cache-in-memory": "4.23.3",
-        "@algolia/client-common": "4.23.3",
-        "@algolia/client-search": "4.23.3",
-        "@algolia/logger-common": "4.23.3",
-        "@algolia/logger-console": "4.23.3",
-        "@algolia/requester-browser-xhr": "4.23.3",
-        "@algolia/requester-common": "4.23.3",
-        "@algolia/requester-node-http": "4.23.3",
-        "@algolia/transporter": "4.23.3"
+        "@algolia/cache-browser-local-storage": "4.24.0",
+        "@algolia/cache-common": "4.24.0",
+        "@algolia/cache-in-memory": "4.24.0",
+        "@algolia/client-common": "4.24.0",
+        "@algolia/client-search": "4.24.0",
+        "@algolia/logger-common": "4.24.0",
+        "@algolia/logger-console": "4.24.0",
+        "@algolia/requester-browser-xhr": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/requester-node-http": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.23.3",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.24.0.tgz",
+      "integrity": "sha512-Z2NxZMb6+nVXSjF13YpjYTdvV3032YTBSGm2vnYvYPA6mMxzM3v5rsCiSspndn9rzIW4Qp1lPHBvuoKJV6jnAA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/requester-common": "4.23.3"
+        "@algolia/requester-common": "4.24.0"
       }
     },
     "node_modules/@algolia/requester-common": {
-      "version": "4.23.3",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.24.0.tgz",
+      "integrity": "sha512-k3CXJ2OVnvgE3HMwcojpvY6d9kgKMPRxs/kVohrwF5WMr2fnqojnycZkxPoEg+bXm8fi5BBfFmOqgYztRtHsQA==",
       "license": "MIT"
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.23.3",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.24.0.tgz",
+      "integrity": "sha512-JF18yTjNOVYvU/L3UosRcvbPMGT9B+/GQWNWnenIImglzNVGpyzChkXLnrSf6uxwVNO6ESGu6oN8MqcGQcjQJw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/requester-common": "4.23.3"
+        "@algolia/requester-common": "4.24.0"
       }
     },
     "node_modules/@algolia/transporter": {
-      "version": "4.23.3",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.24.0.tgz",
+      "integrity": "sha512-86nI7w6NzWxd1Zp9q3413dRshDqAzSbsQjhcDhPIatEFiZrL1/TjnHL8S7jVKFePlIMzDsZWXAXwXzcok9c5oA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/cache-common": "4.23.3",
-        "@algolia/logger-common": "4.23.3",
-        "@algolia/requester-common": "4.23.3"
+        "@algolia/cache-common": "4.24.0",
+        "@algolia/logger-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2312,16 +2355,20 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "3.6.0",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.6.1.tgz",
+      "integrity": "sha512-VtVb5DS+0hRIprU2CO6ZQjK2Zg4QU5HrDM1+ix6rT0umsYvFvatMAnf97NHZlVWDaaLlx7GRfR/7FikANiM2Fg==",
       "license": "MIT"
     },
     "node_modules/@docsearch/react": {
-      "version": "3.6.0",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.6.1.tgz",
+      "integrity": "sha512-qXZkEPvybVhSXj0K7U3bXc233tk5e8PfhoZ6MhPOiik/qUQxYC+Dn9DnoS7CxHQQhHfCvTiN0eY9M12oRghEXw==",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-core": "1.9.3",
         "@algolia/autocomplete-preset-algolia": "1.9.3",
-        "@docsearch/css": "3.6.0",
+        "@docsearch/css": "3.6.1",
         "algoliasearch": "^4.19.1"
       },
       "peerDependencies": {
@@ -2346,7 +2393,9 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "3.3.2",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.5.1.tgz",
+      "integrity": "sha512-N3+9IbGI2jbkiRc6ZbEnU9dC02nHQXi8ivM1VJldkPQyP7WlyHXS+NDhmL3rwaYOMbGH96X2LcKigCKg7pEEqg==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.23.3",
@@ -2359,12 +2408,12 @@
         "@babel/runtime": "^7.22.6",
         "@babel/runtime-corejs3": "^7.22.6",
         "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.3.2",
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/mdx-loader": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/cssnano-preset": "3.5.1",
+        "@docusaurus/logger": "3.5.1",
+        "@docusaurus/mdx-loader": "3.5.1",
+        "@docusaurus/utils": "3.5.1",
+        "@docusaurus/utils-common": "3.5.1",
+        "@docusaurus/utils-validation": "3.5.1",
         "autoprefixer": "^10.4.14",
         "babel-loader": "^9.1.3",
         "babel-plugin-dynamic-import-node": "^2.3.3",
@@ -2431,13 +2480,17 @@
     },
     "node_modules/@docusaurus/core/node_modules/commander": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
       "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.3.2",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.5.1.tgz",
+      "integrity": "sha512-mvtWPLWePlm+4doepxMUT5ynsJQ3CgPtDdbaQh9wm3iAE/7OATBpSgLlfz5N+YtxI5bjIErjbkH8yzISP+S65g==",
       "license": "MIT",
       "dependencies": {
         "cssnano-preset-advanced": "^6.1.2",
@@ -2450,7 +2503,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "3.3.2",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.5.1.tgz",
+      "integrity": "sha512-B36a88CEHCtxIylAV1HNuiiISpoKBqm0UxA6a/JwtHX++Dxb7LNDSGs8ELBlQsZN0OG2tX3tBsCWyaLPwYorkQ==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -2461,12 +2516,14 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.3.2",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.5.1.tgz",
+      "integrity": "sha512-D6Ea2dt32xhoqH+1EuHLGDVSX2HLFiR4QpI0GTU46qOu2hb2ChpQENIUZ2inOsdGFunNa0fCnDG3qn7Kdbzq1A==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/logger": "3.5.1",
+        "@docusaurus/utils": "3.5.1",
+        "@docusaurus/utils-validation": "3.5.1",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -2498,10 +2555,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.3.2",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.5.1.tgz",
+      "integrity": "sha512-SKKdA5RnvZr3pvFXkxtfsBVNgflRGa/bN1HbNi+1s0HNVYPuhB9DFC/CrKe2OoOfUXx7F7k2gg0Jg9gJYDy4rA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.3.2",
+        "@docusaurus/types": "3.5.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2515,17 +2574,20 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.3.2",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.5.1.tgz",
+      "integrity": "sha512-aPmrMV5cDa2QUZ+kPVJID5O6r+ZuLFtHEyneVl9AgryL/9ECudhtpTUdmdnmapnWfUzSSgqYRZ1JtydGLheSzw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/mdx-loader": "3.3.2",
-        "@docusaurus/types": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
-        "cheerio": "^1.0.0-rc.12",
+        "@docusaurus/core": "3.5.1",
+        "@docusaurus/logger": "3.5.1",
+        "@docusaurus/mdx-loader": "3.5.1",
+        "@docusaurus/theme-common": "3.5.1",
+        "@docusaurus/types": "3.5.1",
+        "@docusaurus/utils": "3.5.1",
+        "@docusaurus/utils-common": "3.5.1",
+        "@docusaurus/utils-validation": "3.5.1",
+        "cheerio": "1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
         "lodash": "^4.17.21",
@@ -2540,22 +2602,26 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
+        "@docusaurus/plugin-content-docs": "*",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.3.2",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.5.1.tgz",
+      "integrity": "sha512-DX+I3eVyXak9KqYXg8dgptomqz/O4twjydpLJT8ZSe9lsZ0Pa1ZNPwmftWYn160O3o6GGeUYzr13Y1Got3iXRQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/mdx-loader": "3.3.2",
-        "@docusaurus/module-type-aliases": "3.3.2",
-        "@docusaurus/types": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.5.1",
+        "@docusaurus/logger": "3.5.1",
+        "@docusaurus/mdx-loader": "3.5.1",
+        "@docusaurus/module-type-aliases": "3.5.1",
+        "@docusaurus/theme-common": "3.5.1",
+        "@docusaurus/types": "3.5.1",
+        "@docusaurus/utils": "3.5.1",
+        "@docusaurus/utils-common": "3.5.1",
+        "@docusaurus/utils-validation": "3.5.1",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -2574,14 +2640,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.3.2",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.5.1.tgz",
+      "integrity": "sha512-V2PDVrO2vHYJ7uhrEHpfzg3TTuwfrgNC0pGhM5gXaMfCbdhKm7iwV0huGLcyIX5Peyh7EMP2e8GFccUzWFMYOg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/mdx-loader": "3.3.2",
-        "@docusaurus/types": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.5.1",
+        "@docusaurus/mdx-loader": "3.5.1",
+        "@docusaurus/types": "3.5.1",
+        "@docusaurus/utils": "3.5.1",
+        "@docusaurus/utils-validation": "3.5.1",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
@@ -2595,12 +2663,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.3.2",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.5.1.tgz",
+      "integrity": "sha512-teFZamoECDiELwM1cx5OXd6dBpRtHarc7kWGL1iQozAkYcobZmqOWykBl4joMjSWUbJlx5v9/CVciykWbFNXjA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/types": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
+        "@docusaurus/core": "3.5.1",
+        "@docusaurus/types": "3.5.1",
+        "@docusaurus/utils": "3.5.1",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^1.2.0",
         "tslib": "^2.6.0"
@@ -2614,12 +2684,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.3.2",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.5.1.tgz",
+      "integrity": "sha512-5FUiYZQWPXTPucMzaOOM25R7IwIPvMKbiB0SNVGtxVsGyFyo5i5fzrkBQl4mkZd7uqmslEPzwYbC28ZeFnrxjg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/types": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.5.1",
+        "@docusaurus/types": "3.5.1",
+        "@docusaurus/utils-validation": "3.5.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2631,12 +2703,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.3.2",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.5.1.tgz",
+      "integrity": "sha512-jxBtLBPMv9BJXPXrwJSs69qYcHP/evT1NkVza2yOai7wi5r3E1tVm0bAxdciWitpM0dgS/HDa30qXE7vA1NRDg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/types": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.5.1",
+        "@docusaurus/types": "3.5.1",
+        "@docusaurus/utils-validation": "3.5.1",
         "@types/gtag.js": "^0.0.12",
         "tslib": "^2.6.0"
       },
@@ -2649,12 +2723,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.3.2",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.5.1.tgz",
+      "integrity": "sha512-W5WsKoRmb3lDmg2IBfmKsZDlQAkEx/dXuwr4bj7sSQdM8qd829Rsc4Gp5RddUrQdUz/W3Iocn7LayRM5aacJlA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/types": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.5.1",
+        "@docusaurus/types": "3.5.1",
+        "@docusaurus/utils-validation": "3.5.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2666,15 +2742,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.3.2",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.5.1.tgz",
+      "integrity": "sha512-VXMGJM6uy4jx6HUsFs+kn8MujWGjN7S7p7PYUYSf1bmcFNlf+Qg5vDZtwBElHa2hapeH2AIj2b3QmTgmWeyOHw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/types": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.5.1",
+        "@docusaurus/logger": "3.5.1",
+        "@docusaurus/types": "3.5.1",
+        "@docusaurus/utils": "3.5.1",
+        "@docusaurus/utils-common": "3.5.1",
+        "@docusaurus/utils-validation": "3.5.1",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -2688,22 +2766,24 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "3.3.2",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.5.1.tgz",
+      "integrity": "sha512-afDMZoNYxdloJ7qJJbd3Lmv9uYXKKsEAOtvnvu2945kqe1LUGIIwOo1nMAKgB9y21E5FEvWKnla0MvkMraumZA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/plugin-content-blog": "3.3.2",
-        "@docusaurus/plugin-content-docs": "3.3.2",
-        "@docusaurus/plugin-content-pages": "3.3.2",
-        "@docusaurus/plugin-debug": "3.3.2",
-        "@docusaurus/plugin-google-analytics": "3.3.2",
-        "@docusaurus/plugin-google-gtag": "3.3.2",
-        "@docusaurus/plugin-google-tag-manager": "3.3.2",
-        "@docusaurus/plugin-sitemap": "3.3.2",
-        "@docusaurus/theme-classic": "3.3.2",
-        "@docusaurus/theme-common": "3.3.2",
-        "@docusaurus/theme-search-algolia": "3.3.2",
-        "@docusaurus/types": "3.3.2"
+        "@docusaurus/core": "3.5.1",
+        "@docusaurus/plugin-content-blog": "3.5.1",
+        "@docusaurus/plugin-content-docs": "3.5.1",
+        "@docusaurus/plugin-content-pages": "3.5.1",
+        "@docusaurus/plugin-debug": "3.5.1",
+        "@docusaurus/plugin-google-analytics": "3.5.1",
+        "@docusaurus/plugin-google-gtag": "3.5.1",
+        "@docusaurus/plugin-google-tag-manager": "3.5.1",
+        "@docusaurus/plugin-sitemap": "3.5.1",
+        "@docusaurus/theme-classic": "3.5.1",
+        "@docusaurus/theme-common": "3.5.1",
+        "@docusaurus/theme-search-algolia": "3.5.1",
+        "@docusaurus/types": "3.5.1"
       },
       "engines": {
         "node": ">=18.0"
@@ -2714,25 +2794,27 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "3.3.2",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.5.1.tgz",
+      "integrity": "sha512-k8rLMwHuTc3SqYekc20s1uZHjabt9yi6mt1RUjbkwmjsJlAB6zrtYvsB+ZxrhY5yeUD8DZm3h0qVvKbClHVCCA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/mdx-loader": "3.3.2",
-        "@docusaurus/module-type-aliases": "3.3.2",
-        "@docusaurus/plugin-content-blog": "3.3.2",
-        "@docusaurus/plugin-content-docs": "3.3.2",
-        "@docusaurus/plugin-content-pages": "3.3.2",
-        "@docusaurus/theme-common": "3.3.2",
-        "@docusaurus/theme-translations": "3.3.2",
-        "@docusaurus/types": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.5.1",
+        "@docusaurus/mdx-loader": "3.5.1",
+        "@docusaurus/module-type-aliases": "3.5.1",
+        "@docusaurus/plugin-content-blog": "3.5.1",
+        "@docusaurus/plugin-content-docs": "3.5.1",
+        "@docusaurus/plugin-content-pages": "3.5.1",
+        "@docusaurus/theme-common": "3.5.1",
+        "@docusaurus/theme-translations": "3.5.1",
+        "@docusaurus/types": "3.5.1",
+        "@docusaurus/utils": "3.5.1",
+        "@docusaurus/utils-common": "3.5.1",
+        "@docusaurus/utils-validation": "3.5.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
-        "infima": "0.2.0-alpha.43",
+        "infima": "0.2.0-alpha.44",
         "lodash": "^4.17.21",
         "nprogress": "^0.2.0",
         "postcss": "^8.4.26",
@@ -2752,16 +2834,15 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "3.3.2",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.5.1.tgz",
+      "integrity": "sha512-r34YDzSjggX+B+8W+mG2dVh1ps4JJRCiyq8E1LnZIKLU6F89I2KpAZpPQ2/njKsKhBRLtQ1x92HVkD0FZ3xjrg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.3.2",
-        "@docusaurus/module-type-aliases": "3.3.2",
-        "@docusaurus/plugin-content-blog": "3.3.2",
-        "@docusaurus/plugin-content-docs": "3.3.2",
-        "@docusaurus/plugin-content-pages": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
+        "@docusaurus/mdx-loader": "3.5.1",
+        "@docusaurus/module-type-aliases": "3.5.1",
+        "@docusaurus/utils": "3.5.1",
+        "@docusaurus/utils-common": "3.5.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2775,20 +2856,22 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
+        "@docusaurus/plugin-content-docs": "*",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       }
     },
     "node_modules/@docusaurus/theme-mermaid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.3.2.tgz",
-      "integrity": "sha512-JY6q7owe5S5iH2N9oTjNDkqmuPW/+4j/zrX46Xag4RYOzt+WtMkeJilbzak8QGG8I2wDJXjUvX7Lu/jWuDAwUg==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.5.1.tgz",
+      "integrity": "sha512-yCYNMuRVcAUsn2Nods+SjYWsifAO76JXgsMHzb6ZFaVNfvXBWxX77ZdotsLAsA43apnPC4BMQ31Ux41dT155vg==",
+      "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/module-type-aliases": "3.3.2",
-        "@docusaurus/theme-common": "3.3.2",
-        "@docusaurus/types": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.5.1",
+        "@docusaurus/module-type-aliases": "3.5.1",
+        "@docusaurus/theme-common": "3.5.1",
+        "@docusaurus/types": "3.5.1",
+        "@docusaurus/utils-validation": "3.5.1",
         "mermaid": "^10.4.0",
         "tslib": "^2.6.0"
       },
@@ -2801,17 +2884,19 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.3.2",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.5.1.tgz",
+      "integrity": "sha512-IcUbgh9YcedANhpa0Q3+67WUKY8G7YkN/pZxVBEFjq3d2bniRKktPv41Nh/+AtGLSNJIcspZwEAs/r/mKSZGug==",
       "license": "MIT",
       "dependencies": {
         "@docsearch/react": "^3.5.2",
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/plugin-content-docs": "3.3.2",
-        "@docusaurus/theme-common": "3.3.2",
-        "@docusaurus/theme-translations": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.5.1",
+        "@docusaurus/logger": "3.5.1",
+        "@docusaurus/plugin-content-docs": "3.5.1",
+        "@docusaurus/theme-common": "3.5.1",
+        "@docusaurus/theme-translations": "3.5.1",
+        "@docusaurus/utils": "3.5.1",
+        "@docusaurus/utils-validation": "3.5.1",
         "algoliasearch": "^4.18.0",
         "algoliasearch-helper": "^3.13.3",
         "clsx": "^2.0.0",
@@ -2830,7 +2915,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.3.2",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.5.1.tgz",
+      "integrity": "sha512-fyzQOWrTm0+ZpTlS0/xHsIK4f+LA4qVFrq8rCzIHjxZRip/noYUOwF64lA95vcuw6qnOVBoNE/LyfbBvExnpcw==",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.1.1",
@@ -2841,7 +2928,9 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.3.2",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.5.1.tgz",
+      "integrity": "sha512-IXTGQBoXAGFliGF5Cn3F+gSGskgzAL8+4y6dDY1gcePA0r8WngHj8oovS1YPv+b9JOff32nv8YGGZITHOMXJsA==",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
@@ -2867,11 +2956,13 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.3.2",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.5.1.tgz",
+      "integrity": "sha512-/4QAvXyiQviz2FQ4ct5l1ckvDihIdjS8FsOExC0T+Y1UD38jgPbjTwRJXsDaRsDRCCrDAtXvlonxXw2kixcnXw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
+        "@docusaurus/logger": "3.5.1",
+        "@docusaurus/utils-common": "3.5.1",
         "@svgr/webpack": "^8.1.0",
         "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
@@ -2888,6 +2979,7 @@
         "shelljs": "^0.8.5",
         "tslib": "^2.6.0",
         "url-loader": "^4.1.1",
+        "utility-types": "^3.10.0",
         "webpack": "^5.88.1"
       },
       "engines": {
@@ -2903,7 +2995,9 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.3.2",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.5.1.tgz",
+      "integrity": "sha512-374n6/IW34gHR65JMMN33XLFogTCsrGVPQDVbv2vG96EYHvYzE/plfcGV7xSbXB8yS1YHsxVfvNgVUGi973bfQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.6.0"
@@ -2921,14 +3015,18 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.3.2",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.5.1.tgz",
+      "integrity": "sha512-LZdQnqVVLStgTCn0rfvf4wuOQkjPbGtLXJIQ449em1wJeSFO7lfmn5VGUNLt+xKHvIPfN272EHG8BuvijCI0+A==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
+        "@docusaurus/logger": "3.5.1",
+        "@docusaurus/utils": "3.5.1",
+        "@docusaurus/utils-common": "3.5.1",
+        "fs-extra": "^11.2.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -4295,6 +4393,8 @@
     },
     "node_modules/@types/gtag.js": {
       "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.12.tgz",
+      "integrity": "sha512-YQV9bUsemkzG81Ea295/nF/5GijnD2Af7QhEofh7xu+kvCN6RdodgNwwGWXB5GMI3NoyvQo0odNctoH/qLMIpg==",
       "license": "MIT"
     },
     "node_modules/@types/hast": {
@@ -4473,6 +4573,8 @@
     },
     "node_modules/@types/sax": {
       "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -4921,28 +5023,32 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.23.3",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.24.0.tgz",
+      "integrity": "sha512-bf0QV/9jVejssFBmz2HQLxUadxk574t4iwjCKp5E7NBzwKkrDEhKPISIIjAU/p6K5qDx3qoeh4+26zWN1jmw3g==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.23.3",
-        "@algolia/cache-common": "4.23.3",
-        "@algolia/cache-in-memory": "4.23.3",
-        "@algolia/client-account": "4.23.3",
-        "@algolia/client-analytics": "4.23.3",
-        "@algolia/client-common": "4.23.3",
-        "@algolia/client-personalization": "4.23.3",
-        "@algolia/client-search": "4.23.3",
-        "@algolia/logger-common": "4.23.3",
-        "@algolia/logger-console": "4.23.3",
-        "@algolia/recommend": "4.23.3",
-        "@algolia/requester-browser-xhr": "4.23.3",
-        "@algolia/requester-common": "4.23.3",
-        "@algolia/requester-node-http": "4.23.3",
-        "@algolia/transporter": "4.23.3"
+        "@algolia/cache-browser-local-storage": "4.24.0",
+        "@algolia/cache-common": "4.24.0",
+        "@algolia/cache-in-memory": "4.24.0",
+        "@algolia/client-account": "4.24.0",
+        "@algolia/client-analytics": "4.24.0",
+        "@algolia/client-common": "4.24.0",
+        "@algolia/client-personalization": "4.24.0",
+        "@algolia/client-search": "4.24.0",
+        "@algolia/logger-common": "4.24.0",
+        "@algolia/logger-console": "4.24.0",
+        "@algolia/recommend": "4.24.0",
+        "@algolia/requester-browser-xhr": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/requester-node-http": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.19.0",
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.22.3.tgz",
+      "integrity": "sha512-2eoEz8mG4KHE+DzfrBTrCmDPxVXv7aZZWPojAJFtARpxxMO6lkos1dJ+XDCXdPvq7q3tpYWRi6xXmVQikejtpA==",
       "license": "MIT",
       "dependencies": {
         "@algolia/events": "^4.0.1"
@@ -6537,6 +6643,8 @@
     },
     "node_modules/copy-text-to-clipboard": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.2.0.tgz",
+      "integrity": "sha512-RnJFp1XR/LOBDckxTib5Qjr/PMfkatD0MUCQgdpqS8MdKiNUzBjAQBEN6oUy+jW7LI93BBG3DtMB2KOOKpGs2Q==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7003,6 +7111,8 @@
     },
     "node_modules/cssnano-preset-advanced": {
       "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-6.1.2.tgz",
+      "integrity": "sha512-Nhao7eD8ph2DoHolEzQs5CfRpiEP0xa1HBdnFZ82kvqdmbwVBUr2r1QuQ4t1pi+D1ZpqpcO4T+wy/7RxzJ/WPQ==",
       "license": "MIT",
       "dependencies": {
         "autoprefixer": "^10.4.19",
@@ -7604,6 +7714,7 @@
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
       "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -9277,6 +9388,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
       "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
@@ -10400,6 +10512,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
       "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/highlight.js": {
@@ -10853,7 +10966,9 @@
       }
     },
     "node_modules/infima": {
-      "version": "0.2.0-alpha.43",
+      "version": "0.2.0-alpha.44",
+      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.44.tgz",
+      "integrity": "sha512-tuRkUSO/lB3rEhLJk25atwAjgLuzq070+pOW8XcvpHky/YbENnRRdPd85IBkyeTgttmOy5ah+yHYsK1HhUd4lQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -11603,6 +11718,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
       "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -14499,6 +14615,8 @@
     },
     "node_modules/nprogress": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
+      "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==",
       "license": "MIT"
     },
     "node_modules/nth-check": {
@@ -15279,6 +15397,7 @@
       "version": "11.2.2",
       "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-11.2.2.tgz",
       "integrity": "sha512-2FnyGir8nAJAqD3srROdrF1J5BIcMT4nwj7hHSc60El6Uxlym00UbCCd8pYIterstVBFlMyF1yFV8XdGIPbj4A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "colorette": "^2.0.7",
@@ -15304,6 +15423,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -15328,6 +15448,7 @@
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
       "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -15344,6 +15465,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.0.1.tgz",
       "integrity": "sha512-hTSD/6JMLyT4r9zeof6UtuBDpjJ9sO08/nmS5djaA9eozT9oOlNdpXSnzcgj4FTqpk3nkLrs61l4gip9r1HCrQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
@@ -15651,6 +15773,8 @@
     },
     "node_modules/postcss-discard-unused": {
       "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-6.0.5.tgz",
+      "integrity": "sha512-wHalBlRHkaNnNwfC8z+ppX57VhvS+HWgjW508esjdaEYr3Mx7Gnn2xA4R/CKf5+Z9S5qsqC+Uzh4ueENWwCVUA==",
       "license": "MIT",
       "dependencies": {
         "postcss-selector-parser": "^6.0.16"
@@ -15889,6 +16013,8 @@
     },
     "node_modules/postcss-merge-idents": {
       "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-6.0.3.tgz",
+      "integrity": "sha512-1oIoAsODUs6IHQZkLQGO15uGEbK3EAl5wi9SS8hs45VgsxQfMnxvt+L+zIr7ifZFIH14cfAeVe2uCTa+SPRa3g==",
       "license": "MIT",
       "dependencies": {
         "cssnano-utils": "^4.0.2",
@@ -16186,6 +16312,8 @@
     },
     "node_modules/postcss-reduce-idents": {
       "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-6.0.3.tgz",
+      "integrity": "sha512-G3yCqZDpsNPoQgbDUy3T0E6hqOQ5xigUtBQyrmq3tn2GxlyiL0yyl7H+T8ulQR6kOcHJ9t7/9H4/R2tv8tJbMA==",
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
@@ -16333,6 +16461,8 @@
     },
     "node_modules/postcss-sort-media-queries": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-sort-media-queries/-/postcss-sort-media-queries-5.2.0.tgz",
+      "integrity": "sha512-AZ5fDMLD8SldlAYlvi8NIqo0+Z8xnXU2ia0jxmuhxAU+Lqt9K+AlmLNJ/zWEnE9x+Zx3qL3+1K20ATgNOr3fAA==",
       "license": "MIT",
       "dependencies": {
         "sort-css-media-queries": "2.2.0"
@@ -16377,6 +16507,8 @@
     },
     "node_modules/postcss-zindex": {
       "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-6.0.2.tgz",
+      "integrity": "sha512-5BxW9l1evPB/4ZIc+2GobEBoKC+h8gPGCMi+jxsYvd2x0mjq7wazk6DrP71pStqxE9Foxh5TVnonbWpFZzXaYg==",
       "license": "MIT",
       "engines": {
         "node": "^14 || ^16 || >=18.0"
@@ -16945,6 +17077,8 @@
     },
     "node_modules/react-json-view-lite": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-1.4.0.tgz",
+      "integrity": "sha512-wh6F6uJyYAmQ4fK0e8dSQMEWuvTs2Wr3el3sLD9bambX1+pSWUVXIz1RFaoy3TI1mZ0FqdpKq9YgbgTTgyrmXA==",
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -18251,7 +18385,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/rtlcss": {
-      "version": "4.1.1",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-4.2.0.tgz",
+      "integrity": "sha512-AV+V3oOVvCrqyH5Q/6RuT1IDH1Xy5kJTkEWTWZPN5rdQ3HCFOd8SrbC7c6N5Y8bPpCfZSR6yYbUATXslvfvu5g==",
       "license": "MIT",
       "dependencies": {
         "escalade": "^3.1.1",
@@ -18389,7 +18525,9 @@
       }
     },
     "node_modules/search-insights": {
-      "version": "2.13.0",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.16.2.tgz",
+      "integrity": "sha512-+KrS5rnYlyWgzoCNJGsNPw7Vv+47Y7Ze7KZ+/9Xls+5BUugEbU2yv1n9JsQOqv+MLKYfg3bxI5K6tYJxXZY8FA==",
       "license": "MIT",
       "peer": true
     },
@@ -18408,6 +18546,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
       "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/select-hose": {
@@ -18834,7 +18973,9 @@
       "license": "MIT"
     },
     "node_modules/sitemap": {
-      "version": "7.1.1",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.1.2.tgz",
+      "integrity": "sha512-ARCqzHJ0p4gWt+j7NlU5eDlIO9+Rkr/JhPFZKKQ1l5GCus7rJH4UdrlVAh0xC/gDS/Qir2UMxqYNHtsKr2rpCw==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^17.0.5",
@@ -18852,6 +18993,8 @@
     },
     "node_modules/sitemap/node_modules/@types/node": {
       "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
       "license": "MIT"
     },
     "node_modules/skin-tone": {
@@ -18948,6 +19091,8 @@
     },
     "node_modules/sort-css-media-queries": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/sort-css-media-queries/-/sort-css-media-queries-2.2.0.tgz",
+      "integrity": "sha512-0xtkGhWCC9MGt/EzgnvbbbKhqWjl1+/rncmhTh5qCpbYguXh6S/qwePfv/JQ8jePXXmqingylxoC49pCkSPIbA==",
       "license": "MIT",
       "engines": {
         "node": ">= 6.3.0"
@@ -19471,23 +19616,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/swagger-ui-dist": {
-      "version": "5.15.1",
-      "license": "Apache-2.0"
-    },
-    "node_modules/swagger-ui-express": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "swagger-ui-dist": ">=5.0.0"
-      },
-      "engines": {
-        "node": ">= v0.10.32"
-      },
-      "peerDependencies": {
-        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/swagger2openapi": {
@@ -21353,7 +21481,7 @@
     },
     "schema": {
       "name": "@morio/schema",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "EUPL",
       "dependencies": {
         "joi": "^17.11.0"
@@ -21362,7 +21490,7 @@
     },
     "shared": {
       "name": "@morio/shared",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "EUPL",
       "dependencies": {
         "bson": "^6.6.0",
@@ -21395,7 +21523,7 @@
       }
     },
     "ui": {
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "EUPL",
       "dependencies": {
         "@mdx-js/loader": "^3.0.1",


### PR DESCRIPTION
On Friday, [Docusaurus 3.5 was released](https://docusaurus.io/blog/releases/3.5) so this PR updates the docs dependencies to ensure we're on the latest and greatest.

It also makes some other changes based on the new features in Docusaurus 3.5:

- Add author social links (didn't add them for other authors, more as an example)
- Add author page/description
- Enforce the use of global authors and truncated posts

In addition, this bumps the version in the OpenAPI spec files to the (current) v0.3.0.