### PR TITLE
fix: Don't assume latest tag when publishing images

### DIFF
--- a/scripts/ci-build-container.sh
+++ b/scripts/ci-build-container.sh
@@ -129,12 +129,12 @@ else
     fi
 
     echo "Attempting to publish image: Tag = latest"
-    buildah push docker.io/itsmorio/$IMAGE:latest
+    buildah push docker.io/itsmorio/$IMAGE:$MORIO_RELEASE
     if [ $? -eq 0 ]
     then
-      echo "Successfully pushed image: itsmorio/$IMAGE:latest"
+      echo "Successfully pushed image: itsmorio/$IMAGE:$MORIO_RELEASE"
     else
-      echo "Failed to push image: itsmorio/$IMAGE:latest"
+      echo "Failed to push image: itsmorio/$IMAGE:$MORIO_RELEASE"
       exit 1
     fi
 


### PR DESCRIPTION
We build images with the `next` tag for pre-releases, but when publishing the image to hub.docker.com, we (or rather our script) still assumed the image was tagged as `latest` which caused publishing of non-production images to fail.