### PR TITLE
feat [api]: Implement the varlous DISABLE_IDP_* feature flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- We no longer provide AMI images, and removed the docs, config and tooling for them
+- We have discontinued support for AMI images and have removed the related documentation, configurations, and tools.
 
 ## [0.5.0] - 2024-10-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [ui] Added feature flag settings to the UI
+
 ### Removed
 
 - We no longer provide AMI images, and removed the docs, config and tooling for them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [api] Implemented the various `DISABLE_IDP_[type]` feature flags
 - [ui] Added feature flag settings to the UI
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- We no longer provide AMI images, and removed the docs, config and tooling for them
+
 ## [0.5.0] - 2024-10-25
 
 Since this is a minor release, here's what's new since 0.4.0:

--- a/api/src/controllers/anonymous.mjs
+++ b/api/src/controllers/anonymous.mjs
@@ -77,21 +77,15 @@ Controller.prototype.getIdps = async function (req, res) {
       if (id === 'mrt') provider = 'mrt'
       else if (id === 'local') provider = 'local'
       else if (id === 'apikey') provider = 'apikey'
-      idps[id] = {
-        id,
-        provider,
-        label: conf.label,
-        about: conf.about || false,
+      if (!utils.getFlag(`DISABLE_IDP_${provider.toUpperCase()}`, false)) {
+        idps[id] = {
+          id,
+          provider,
+          label: conf.label,
+          about: conf.about || false,
+        }
       }
     }
-  }
-
-  /*
-   * Add the root token IDP, unless it's disabled by a feature flag
-   */
-  if (!utils.getFlag('DISABLE_ROOT_TOKEN')) {
-    // TODO: Why is this commented out?
-    //idps['Root Token'] = { id: 'mrt', provider: 'mrt' }
   }
 
   /*

--- a/api/src/errors.mjs
+++ b/api/src/errors.mjs
@@ -8,6 +8,14 @@ export const errors = {
     detail: 'This is the API equivalent of a 404 page. The endpoint you requested does not exist.',
   },
   /*
+   * Identity provider is disabled by a feature flag
+   */
+  'morio.api.idp.disabled': {
+    status: 400,
+    title: 'Provider Disabled',
+    detail: 'This identity provider is disabled by a feature flag.',
+  },
+  /*
    * KV store 404 error, API style
    */
   'morio.api.kv.404': {

--- a/api/src/idps/apikey.mjs
+++ b/api/src/idps/apikey.mjs
@@ -1,5 +1,6 @@
 import { updateLastLoginTime, loadApikey } from '../lib/apikey.mjs'
 import { verifyPassword } from '#shared/crypto'
+import { utils } from '../lib/utils.mjs'
 
 /**
  * apikey: API key identity/authentication provider
@@ -17,6 +18,19 @@ export async function apikey(id, data) {
    * Authenticate
    */
   if (id === 'apikey' && data?.api_key && data?.api_key_secret) {
+    /*
+     * Check feature flag
+     */
+    if (utils.getFlag(`DISABLE_IDP_APIKEY`, false))
+      return [
+        false,
+        {
+          success: false,
+          reason: 'Authentication failed',
+          error: 'Identity provider disabled by feature flag',
+        },
+      ]
+
     /*
      * Look up the apikey
      */

--- a/api/src/idps/ldap.mjs
+++ b/api/src/idps/ldap.mjs
@@ -68,6 +68,11 @@ const strategy = (id) => {
  */
 export function ldap(id, data, req) {
   /*
+   * Check feature flag
+   */
+  if (utils.getFlag(`DISABLE_IDP_LDAP`, false)) return [false, `morio.api.idp.disabled`]
+
+  /*
    * Add strategy to passport if it hasn't been used yet
    */
   if (passport._strategies[id] === undefined) {

--- a/api/src/idps/local.mjs
+++ b/api/src/idps/local.mjs
@@ -22,6 +22,11 @@ export async function local(id, data) {
    */
   if (id === 'local' && data?.username && data?.password && data?.token && data?.role) {
     /*
+     * Check feature flag
+     */
+    if (utils.getFlag(`DISABLE_IDP_LOCAL`, false)) return [false, `morio.api.idp.disabled`]
+
+    /*
      * Look up the account
      */
     const account = await loadAccount('local', data.username)

--- a/api/src/idps/mrt.mjs
+++ b/api/src/idps/mrt.mjs
@@ -16,6 +16,11 @@ import { verifyPassword } from '#shared/crypto'
  */
 export async function mrt(id, data) {
   /*
+   * Check feature flag
+   */
+  if (utils.getFlag(`DISABLE_IDP_MRT`, false)) return [false, `morio.api.idp.disabled`]
+
+  /*
    * Authenticate
    */
   const keys = utils.getKeys()

--- a/api/src/idps/oidc.mjs
+++ b/api/src/idps/oidc.mjs
@@ -42,7 +42,7 @@ export async function oidc(id, req, res) {
   /*
    * Check feature flag
    */
-  if (utils.getFlag(`DISABLE_IDP_OICD`, false))
+  if (utils.getFlag(`DISABLE_IDP_OIDC`, false))
     return utils.sendErrorResponse(res, 'morio.api.idp.disabled', req.url)
 
   /*

--- a/api/src/idps/oidc.mjs
+++ b/api/src/idps/oidc.mjs
@@ -40,6 +40,12 @@ import { checkRole, caseInsensitiveGet } from './ldap.mjs'
  */
 export async function oidc(id, req, res) {
   /*
+   * Check feature flag
+   */
+  if (utils.getFlag(`DISABLE_IDP_OICD`, false))
+    return utils.sendErrorResponse(res, 'morio.api.idp.disabled', req.url)
+
+  /*
    * Get the OIDC client
    */
   const client = await getClient(id)

--- a/api/src/lib/utils.mjs
+++ b/api/src/lib/utils.mjs
@@ -460,7 +460,7 @@ utils.endReload = () => {
  */
 
 /**
- * Clear OIDC PKCE data after an OICD flow
+ * Clear OIDC PKCE data after an OIDC flow
  */
 utils.clearOidcPkce = (id, state) => store.unset(['oidc', 'pkce', id, state])
 

--- a/config/flags.mjs
+++ b/config/flags.mjs
@@ -1,45 +1,90 @@
 /*
  * Morio feature flags
  */
+export const fdocs = {}
 export const flags = {}
 
 /*
  * Disable the apikey identity provider
  */
+fdocs.DISABLE_IDP_APIKEY = `Enable this flag to disable the \`apikey\` identity
+provider thereby blocking authentication via API Keys.`
 flags.DISABLE_IDP_APIKEY = false
 
 /*
  * Disable the ldap identity provider
  */
+fdocs.DISABLE_IDP_LDAP = `Enable this flag to disable the \`ldap\` identity
+provider thereby blocking authentication via any LDAP backend.`
 flags.DISABLE_IDP_LDAP = false
 
 /*
  * Disable the local identity provider
  */
+fdocs.DISABLE_IDP_LOCAL = `Enable this flag to disable the \`local\` identity
+provider thereby blocking authentication via local Morio accounts.`
 flags.DISABLE_IDP_LOCAL = false
 
 /*
  * Disable the mrt identity provider
  */
+fdocs.DISABLE_IDP_MRT = `Enable this flag to disable the \`mrt\` identity
+provider thereby blocking authentication via Morio Root Token.
+
+Note that if you enable this flag in your initial settings, you will have
+effectively locked yourself out of your Morio deployment unless you have also
+included an alternative identity provider.
+
+As such, we recommend to not enable this flag until after you have made sure
+you have an alternative identity provider that you know is functioning as
+expected.`
 flags.DISABLE_IDP_MRT = false
 
 /*
  * Disable the iodc identity provider
  */
+fdocs.DISABLE_IDP_OIDC = `Enable this flag to disable the \`oidc\` identity
+provider thereby blocking authentication via any OpenID Connect backend.`
 flags.DISABLE_IDP_OIDC = false
-
-/*
- * Enforces mTLS on all HTTP endpoints
- */
-flags.ENFORCE_HTTP_MTLS = false
 
 /*
  * Disable the UI service
  */
+fdocs.DISABLE_SERVICE_UI = `Enable this flag to disable the UI service and run Morio in headless mode where you can only use the API to manage it.`
 flags.DISABLE_SERVICE_UI = false
+
+/*
+ * Enforces mTLS on all HTTP endpoints
+ */
+fdocs.ENFORCE_HTTP_MTLS = `Enable this feature flag to enforce \`mTLS\` on all
+HTTP endpoints.
+
+The purpose of this feature flag is to add an extra layer of defence so prevent
+anyone from being able to establish an HTTP connection to your Morio instance.
+This is useful when deploying Morio in hostile environments, such as on the
+Internet.
+
+The extra mTLS authentication comes in addition to Morio’s standard HTTP
+authentication.  In other words, this is not a replacement for any other
+authentication, but adds an extra authentication layer.`
+flags.ENFORCE_HTTP_MTLS = false
 
 /*
  * Reseed the config when reloading/restarting
  */
+fdocs.RESEED_ON_RELOAD = `Enable this flag to reseed Morio when reloading.
+
+This flag comes into play when you have have preseed.git settings that make
+Morio clone a git repository locally. This gives you various ways to keep your
+configuration under version control, as outlined in the Preseeding Guide.
+
+By default, Morio will not re-clone the repository when you make a
+configuration change, or when you restart Morio. Instead, it will only update
+the git repository from the remote when you explicitly reseed Morio through the
+reseed API endpoint, (or via the UI which uses this endpoint under the hood).
+
+When you enable this flag, Morio will reseed (thus update the local git
+content from the remote) whenever you restart it, or update its
+configuration.`
 flags.RESEED_ON_RELOAD = false
 

--- a/config/presets.mjs
+++ b/config/presets.mjs
@@ -33,7 +33,7 @@ it can also be changed on a running Morio system.  To do so:
 presets.MORIO_DOCKER_SOCKET = '/var/run/docker.sock'
 
 predocs.MORIO_CONFIG_ROOT = `Location of the Morio configuration folder on the
-host OS
+host OS.
 
 You can only change this on a fresh Morio install. To do so:
 
@@ -44,7 +44,7 @@ You can only change this on a fresh Morio install. To do so:
 `
 presets.MORIO_CONFIG_ROOT = '/etc/morio/moriod'
 
-predocs.MORIO_DATA_ROOT = `Location of the Morio data folder on the host OS
+predocs.MORIO_DATA_ROOT = `Location of the Morio data folder on the host OS.
 
 You can only change this on a fresh Morio install. To do so:
 
@@ -55,7 +55,7 @@ You can only change this on a fresh Morio install. To do so:
 `
 presets.MORIO_DATA_ROOT = '/var/lib/morio/moriod'
 
-predocs.MORIO_LOGS_ROOT = `Location of the Morio logs folder on the host OS
+predocs.MORIO_LOGS_ROOT = `Location of the Morio logs folder on the host OS.
 
 You would typically change this on a fresh Morio install, but it can also be
 changed on a running Morio instance. To do so:
@@ -93,10 +93,10 @@ presets.MORIO_NETWORK_SUBNET = '192.168.144.32/28'
 predocs.MORIO_NETWORK_MTU = `MTU to configure on the internal Morio Docker
 network.
 
-If you are considering changing the MTU you probably know what you're doing.
-But in general this can be useful to avoid fragmentation.
+If you are considering changing the MTU, you probably know what you're doing.
+In general, this can be useful to avoid fragmentation.
 
-  To change this, set \`tokens.presets.MORIO_NETWORK_MTU\` in your Morio
+To change this, set \`tokens.presets.MORIO_NETWORK_MTU\` in your Morio
 settings.`
 presets.MORIO_NETWORK_MTU = 1500
 
@@ -113,7 +113,7 @@ presets.MORIO_CONTAINER_PREFIX = "morio-"
 predocs.MORIO_DOCKER_LOG_DRIVER = `The Docker log driver to use for created
 containers.
 
-Morio assumes \`systemd\` is present, and so we use the \`journald\` log
+Morio assumes that \`systemd\` is present, and so we use the \`journald\` log
 driver for Docker. If you are running Morio on a system without \`systemd\`
 you will need to change this.
 
@@ -133,8 +133,8 @@ presets.MORIO_DOCKER_LOG_DRIVER = 'journald'
 predocs.MORIO_DOCKER_ADD_HOST = `Optional \`host:ip\` resolution to add to the
 containers configuration.
 
-This is typically used in facilitate development or testing of Morio.
-It is not the kind of thing you want to run use production, use DNS instead.
+This is typically used to facilitate the development or testing of Morio.
+It is not the kind of thing that you want to run in production: use DNS instead.
 
 To update this, set the \`MORIO_DOCKER_ADD_HOST\` environment variable when
 launching the Morio core container.`
@@ -147,7 +147,7 @@ presets.MORIO_DOCKER_ADD_HOST = false
 predocs.MORIO_API_JWT_EXPIRY = `Maximum lifetime of a JSON Web Token generated
 by Morio.
 
-The notation here is the one use by [Go's time
+The notation here is the one used by [Go's time
 package](https://pkg.go.dev/time#ParseDuration).
 
 To change this, set \`tokens.presets.MORIO_API_JWT_EXPIRY\` in your Morio
@@ -336,10 +336,10 @@ predocs.MORIO_CORE_PREFIX =
 presets.MORIO_CORE_PREFIX = '/-/core'
 
 predocs.MORIO_CORE_CLUSTER_HEARTBEAT_INTERVAL =
-  'Amount of seconds to wait between cluster heartbeats'
+  'Number of seconds to wait between cluster heartbeats'
 presets.MORIO_CORE_CLUSTER_HEARTBEAT_INTERVAL = 30
 
-predocs.MORIO_CORE_CLUSTER_HEARTBEAT_MAX_RTT = `Amount of milliseconds above
+predocs.MORIO_CORE_CLUSTER_HEARTBEAT_MAX_RTT = `Number of milliseconds above
 which we start logging heartbeat latency.
 
 You may want to increase this if you have cluster nodes behind a slower link.

--- a/config/presets.mjs
+++ b/config/presets.mjs
@@ -134,7 +134,7 @@ predocs.MORIO_DOCKER_ADD_HOST = `Optional \`host:ip\` resolution to add to the
 containers configuration.
 
 This is typically used to facilitate the development or testing of Morio.
-It is not the kind of thing that you want to run in production: use DNS instead.
+It is not the kind of setup that you want to run in production: use DNS instead.
 
 To update this, set the \`MORIO_DOCKER_ADD_HOST\` environment variable when
 launching the Morio core container.`

--- a/docs/docs/reference/errors/morio.api.idp.disabled/readme.mdx
+++ b/docs/docs/reference/errors/morio.api.idp.disabled/readme.mdx
@@ -1,0 +1,23 @@
+---
+title: "morio.api.idp.disabled" # skip-spellcheck
+tags:
+ - error
+
+---
+<!-- MORIO_AUTO_GENERATED_CONTENT_STARTS - Manual changes made below will be overwritten skip-spellcheck -->
+__Provider Disabled__ - This identity provider is disabled by a feature flag.
+<!-- MORIO_AUTO_GENERATED_CONTENT_ENDS - Manual changes made above will be overwritten skip-spellcheck -->
+
+
+<!-- MORIO_AUTO_GENERATED_CONTENT_STARTS - Manual changes made below will be overwritten skip-spellcheck -->
+## Example response
+
+```json
+{
+  "type": "https://morio.it/docs/reference/errors/morio.api.idp.disabled",
+  "status": 400,
+  "title": "Provider Disabled",
+  "detail": "This identity provider is disabled by a feature flag."
+}
+```
+<!-- MORIO_AUTO_GENERATED_CONTENT_ENDS - Manual changes made above will be overwritten skip-spellcheck -->

--- a/docs/docs/reference/flags/readme.mdx
+++ b/docs/docs/reference/flags/readme.mdx
@@ -19,29 +19,17 @@ Enable this flag to disable [the `apikey` identity
 provider](/docs/guides/settings/idps#apikey) thereby blocking authentication
 via API Keys.
 
-:::warning FIXME 
-This flag is not implemented yet, but it's on our todo list. 
-:::
-
 ## `DISABLE_IDP_LDAP`
 
 Enable this flag to disable [the `ldap` identity
 provider](/docs/guides/settings/idps#ldap) thereby blocking authentication via
 any LDAP backend.
 
-:::warning FIXME 
-This flag is not implemented yet, but  on our todo list. 
-:::
-
 ## `DISABLE_IDP_LOCAL`
 
 Enable this flag to disable [the `local` identity
 provider](/docs/guides/settings/idps#local) thereby blocking authentication via
 local Morio accounts.
-
-:::warning FIXME 
-This flag is not implemented yet, but  on our todo list. 
-:::
 
 ## `DISABLE_IDP_MRT`
 
@@ -56,10 +44,6 @@ included an alternative identity provider.
 As such, we recommend to not enable this flag until after you have made sure
 you have an alternative identity provider that you know is functioning as
 expected.
-
-:::warning FIXME 
-This flag is not implemented yet, but  on our todo list. 
-:::
 
 :::info You currently cannot rotate the root token
 
@@ -76,10 +60,6 @@ compromised.
 Enable this flag to disable [the `oidc` identity
 provider](/docs/guides/settings/idps#openid-connect) thereby blocking
 authentication via any OpenID Connect backend.
-
-:::warning FIXME 
-This flag is not implemented yet, but  on our todo list. 
-:::
 
 ## `DISABLE_SERVICE_UI`
 

--- a/docs/docs/reference/presets/readme.mdx
+++ b/docs/docs/reference/presets/readme.mdx
@@ -32,7 +32,7 @@ it can also be changed on a running Morio system.  To do so:
 ## MORIO_CONFIG_ROOT
 
 Location of the Morio configuration folder on the
-host OS
+host OS.
 
 You can only change this on a fresh Morio install. To do so:
 

--- a/ui/components/auth/login.mjs
+++ b/ui/components/auth/login.mjs
@@ -124,7 +124,6 @@ export const Login = ({ setAccount, account = false, role = false }) => {
         setLoadingStatus([false])
         clearModal()
       }
-      else console.log({result, status})
     }
     getIdps()
   }, [])

--- a/ui/components/auth/login.mjs
+++ b/ui/components/auth/login.mjs
@@ -124,6 +124,7 @@ export const Login = ({ setAccount, account = false, role = false }) => {
         setLoadingStatus([false])
         clearModal()
       }
+      else console.log({result, status})
     }
     getIdps()
   }, [])

--- a/ui/components/icons.mjs
+++ b/ui/components/icons.mjs
@@ -568,6 +568,15 @@ export const UlIcon = (props) => (
 )
 
 /*
+ * UnavailableIcon - Looks like a forbidden sign
+ */
+export const UnavailableIcon = (props) => (
+  <IconWrapper {...props}>
+    <path d="M18.364 18.364A9 9 0 0 0 5.636 5.636m12.728 12.728A9 9 0 0 1 5.636 5.636m12.728 12.728L5.636 5.636" />
+  </IconWrapper>
+)
+
+/*
  * UserIcon - Looks like a face in a circle
  */
 export const UserIcon = (props) => (

--- a/ui/components/settings/blocks/iam.mjs
+++ b/ui/components/settings/blocks/iam.mjs
@@ -6,10 +6,12 @@ import {
   KeyIcon,
   MorioIcon,
   StorageIcon,
+  UnavailableIcon,
   UserIcon,
   PlayIcon,
 } from 'components/icons.mjs'
 import { ModalContext } from 'context/modal.mjs'
+import { Popout } from 'components/popout.mjs'
 import { ModalWrapper } from 'components/layout/modal-wrapper.mjs'
 import { FormWrapper, loadFormDefaults } from './form.mjs'
 
@@ -38,6 +40,7 @@ const AddProvider = (props) => {
   return (
     <div className="max-w-2xl w-full">
       <ProviderHeader id={props.id} title={props.title} />
+      <ProviderDisabled provider={props.id} flags={props.data.tokens?.flags} />
       {props.form ? (
         <FormWrapper
           {...props}
@@ -48,9 +51,22 @@ const AddProvider = (props) => {
       ) : (
         <p>No form for this type of identity provider</p>
       )}
+
     </div>
   )
 }
+
+const ProviderDisabled = ({ provider, flags={} }) => flags[`DISABLE_IDP_${provider.toUpperCase()}`]
+  ? (
+      <Popout important noP>
+        <h5>This provider type is disabled</h5>
+        <p>The <code>DISABLE_IDP_{provider.toUpperCase()}</code> feature flag is currently active.
+        <br />
+        This disables the <code>{provider}</code> identity provider.
+        </p>
+      </Popout>
+  )
+  : null
 
 const UpdateProvider = (props) => {
   const { provider } = props
@@ -67,6 +83,7 @@ const UpdateProvider = (props) => {
   return (
     <div className="max-w-2xl w-full">
       <ProviderHeader id={props.id} title={props.title} />
+      <ProviderDisabled provider={provider} flags={props.data.tokens?.flags} />
       {props.blocks?.[provider]?.form ? (
         <FormWrapper
           {...props}
@@ -84,7 +101,7 @@ const UpdateProvider = (props) => {
   )
 }
 
-const ProviderButton = ({ title, about, id, type, onClick }) => (
+const ProviderButton = ({ title, about, id, type, onClick, flags={} }) => (
   <div className="indicator w-full">
     <button
       className={`rounded-lg p-0 px-2 shadow hover:bg-secondary hover:bg-opacity-20 hover:cursor-pointer w-full
@@ -95,7 +112,14 @@ const ProviderButton = ({ title, about, id, type, onClick }) => (
         <span className="capitalize text-lg font-bold">{title ? title : id}</span>
         <span className="-mt-1 text-sm italic opacity-80">{about}</span>
       </div>
-      <div>{brands[type] ? brands[type] : <FingerprintIcon {...iconProps} />}</div>
+      <div>
+        {flags[`DISABLE_IDP_${type.toUpperCase()}`]
+          ? <UnavailableIcon className="w-8 h-8 text-error" stroke={2.5}/>
+          : brands[type]
+            ? brands[type]
+            : <FingerprintIcon {...iconProps} />
+          }
+        </div>
     </button>
   </div>
 )
@@ -112,6 +136,7 @@ export const AuthProviders = (props) => {
         <div className="grid grid-cols-2 gap-4 mt-4">
           <ProviderButton
             available
+            flags={data.tokens?.flags}
             id="mrt"
             type="mrt"
             title="Morio Root Token"
@@ -136,6 +161,7 @@ export const AuthProviders = (props) => {
               <ProviderButton
                 available
                 key={id}
+                flags={data.tokens?.flags}
                 id={id}
                 title={data.iam.providers[id].label}
                 type={data.iam.providers[id].provider}
@@ -169,6 +195,7 @@ export const AuthProviders = (props) => {
               key={id}
               id={id}
               type={id}
+              flags={data.tokens?.flags}
               {...blocks[id]}
               onClick={() =>
                 pushModal(
@@ -194,6 +221,7 @@ export const LoginUi = ({ data, update }) => {
 }
 
 const ProviderOrder = ({ data, update }) => {
+  const { pushModal } = useContext(ModalContext)
   /*
    * We need to handle things like providers being removed and so on
    */
@@ -219,18 +247,35 @@ const ProviderOrder = ({ data, update }) => {
 
   return (
     <div className="flex flex-col gap-1">
-      {[...order].map((id, i) => (
-        <div key={id} className="flex flex-row gap-2 items-center p-2 px-4">
-          <span className="w-8 text-center block font-bold opacity-70">{i + 1}</span>
-          <button className="btn btn-ghost btn-sm" disabled={i === 0} onClick={() => moveUp(i)}>
-            <PlayIcon className="w-5 h-5 -rotate-90" fill />
-          </button>
-          <div className="font-bold grow p-1 px-4">{data.iam?.providers?.[id]?.label || id}</div>
-          <div className="w-3/5">
-            <FormWrapper form={providerVisibilityForm(id, data)} update={update} />
+      {[...order].map((id, i) => {
+        const type = (data.iam.providers[id].type || id).toUpperCase()
+        const flag = `DISABLE_IDP_${type}`
+
+        return (
+          <div key={id} className="flex flex-row gap-2 items-center p-2 px-4">
+            <span className="w-8 text-center block font-bold opacity-70">{i + 1}</span>
+            <button className="btn btn-ghost btn-sm" disabled={i === 0} onClick={() => moveUp(i)}>
+              <PlayIcon className="w-5 h-5 -rotate-90" fill />
+            </button>
+            <div className="font-bold grow p-1 px-4 flex flex-row gap-1 items-center">
+              {data.tokens.flags?.[flag]
+                ? <button onClick={() => pushModal(
+                  <ModalWrapper keepOpenOnClick wClass="max-w-2xl w-full">
+                    <h4>This identity provider is disabled by a feature flag</h4>
+                    <p>The <code>{flag}</code> feature flag is active which
+                  disables all identity providers of type
+                  <code>{type.toLowerCase()}, including this one.</code>.</p>
+                  </ModalWrapper>
+                )}><UnavailableIcon className="w-5 h-5 text-error" stroke={3}/></button>
+                : null
+              }
+              {data.iam?.providers?.[id]?.label || id}
+            </div>
+            <div className="w-3/5">
+              <FormWrapper form={providerVisibilityForm(id, data)} update={update} />
+            </div>
           </div>
-        </div>
-      ))}
+        )})}
     </div>
   )
 }

--- a/ui/components/settings/blocks/iam.mjs
+++ b/ui/components/settings/blocks/iam.mjs
@@ -248,7 +248,7 @@ const ProviderOrder = ({ data, update }) => {
   return (
     <div className="flex flex-col gap-1">
       {[...order].map((id, i) => {
-        const type = (data.iam.providers[id].type || id).toUpperCase()
+        const type = (data.iam.providers[id].provider || id).toUpperCase()
         const flag = `DISABLE_IDP_${type}`
 
         return (

--- a/ui/components/settings/blocks/tokens.mjs
+++ b/ui/components/settings/blocks/tokens.mjs
@@ -16,6 +16,8 @@ import { slugify } from 'lib/utils.mjs'
 import { FormControl } from '../../inputs.mjs'
 import SecretSelectDocs from 'mdx/secret-select.mdx'
 import VariableSelectDocs from 'mdx/variable-select.mdx'
+import { flags, fdocs } from 'config/flags.mjs'
+import Markdown from 'react-markdown'
 
 const TokenHelp = ({ secrets, pushModal }) => (
   <button
@@ -264,44 +266,48 @@ export const Tokens = ({ update, data, secrets = false }) => {
 export const Vars = Tokens
 export const Secrets = (props) => <Tokens {...props} secrets />
 
-const flags = {
-  DISABLE_ROOT_TOKEN: 'Block authentication with the Morio Root Token',
-  HEADLESS_MORIO: 'Run Morio in headless mode, where the UI is not available',
-}
-
 export const Flags = ({ update, data }) => (
   <>
     <div className="flex flex-col gap-2">
+      <div className='flex flex-row items-center gap-2 flex-wrap mb-4'>
+        <ul className="list list-inside ml-4 list-disc">
+        {Object.keys(data?.tokens?.flags || {})
+          .sort()
+          .map((key) => <li key={key} className='flex flex-row items-center gap-2 flex-wrap py-0.5'>
+            {data.tokens.flags[key] ? <BoolYesIcon /> : <BoolNoIcon />}
+            <a href={`#${key.toLowerCase()}`} className="textsm">{key}</a>
+          </li>)
+        }
+        </ul>
+      </div>
       {Object.keys(data?.tokens?.flags || {})
         .sort()
         .map((key) => (
-          <label
-            className={`hover:cursor-pointer border-4 border-y-0 border-r-0 p-2
-            hover:border-primary hover:bg-primary hover:bg-opacity-10`}
+          <label id={key.toLowerCase()}
+            className={`scroll-mt-20 hover:cursor-pointer border-4 border-y-0 border-r-0 p-2 px-4 shadow
+            hover:bg-base-100 hover:bg-opacity-10 rounded bg-opacity-10
+            ${data?.tokens?.flags?.[key] ? 'border-success bg-success' : 'border-error bg-error'}
+            `}
             key={key}
             htmlFor={key}
           >
-            <div htmlFor={key} className="flex flex-row gap-2 items-center">
-              {data.tokens.flags[key] ? <BoolYesIcon /> : <BoolNoIcon />}
-              <span
-                className={`badge badge-lg badge-${data.tokens.flags[key] ? 'success' : 'error'}`}
-              >
-                {key}
-              </span>
-            </div>
-            <div className="flex flex-row gap-2 items-center">
+            <div htmlFor={key} className="flex flex-row gap-4 items-center">
+              <h5 className={data?.tokens?.flags?.[key] ? '' : ''}>{key}</h5>
+              <span className='grow'></span>
               <input
                 id={key}
                 type="checkbox"
                 value={data.tokens.flags[key]}
                 onChange={() => update(`tokens.flags.${key}`, !data.tokens.flags[key])}
-                className="toggle my-3 toggle-primary"
+                className="toggle my-3 toggle-success"
                 checked={data.tokens.flags[key]}
               />
               <label className="hover:cursor-pointer" htmlFor={key}>
                 {flags[key]}
               </label>
+              {data.tokens.flags[key] ? <BoolYesIcon /> : <BoolNoIcon />}
             </div>
+            <Markdown>{fdocs[key]}</Markdown>
           </label>
         ))}
     </div>

--- a/ui/components/settings/templates/iam/mrt.mjs
+++ b/ui/components/settings/templates/iam/mrt.mjs
@@ -35,7 +35,7 @@ export const mrt = {
         <p>Keep in mind that this merely enables the Root Token provider for UI logins.</p>
         <p>
           The Root Token provider is always active for API access, although you can disabled that
-          with the <code>DISABLE_ROOT_TOKEN</code> feature flag.
+          with the <code>DISABLE_IDP_MRT</code> feature flag.
         </p>
       </Popout>
     </>,


### PR DESCRIPTION
This implements the following feature flags:

- [DISABLE_IDP_APIKEY](https://morio.it/docs/reference/flags/#disable_idp_apikey)
- [DISABLE_IDP_LDAP](https://morio.it/docs/reference/flags/#disable_idp_ldap)
- [DISABLE_IDP_LOCAL](https://morio.it/docs/reference/flags/#disable_idp_local)
- [DISABLE_IDP_MRT](https://morio.it/docs/reference/flags/#disable_idp_mrt)
- [DISABLE_IDP_OIDC](https://morio.it/docs/reference/flags/#disable_idp_oidc)

These feature flags where already defined (and documented), but they were not actually implemented.

Apart from implementing this feature flags (in the API) this also adds support for managing feature flags through the UI. 
The UI will make it obvious when a configured identity provider is disabled.