### PR TITLE
release: Morio v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2024-11-12
+
 ### Added
 
 - [api] Implemented the various `DISABLE_IDP_[type]` feature flags

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morio/api",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Morio Management API",
   "private": true,
   "scripts": {

--- a/clients/morio/version/main.go
+++ b/clients/morio/version/main.go
@@ -1,3 +1,3 @@
 // This file is auto-generated
 package version
-var Version string = "0.5.0"
+var Version string = "0.5.1"

--- a/config/package.json
+++ b/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morio/config",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Morio Configuration",
   "private": true,
   "scripts": {

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morio/core",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Morio Core",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morio",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Morio provides the plumbing for your observability needs",
   "license": "EUPL",
   "private": true,

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morio/shared",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Morio Library Methods for NodeJS (shared)",
   "private": true,
   "author": "CERT-EU <services@cert.europa.eu>",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "author": "CERT-EU <services@cert.europa.eu>",
   "license": "EUPL",


### PR DESCRIPTION
This is version 0.5.1 of Morio 🎉 


**Added**

- [api] Implemented the various `DISABLE_IDP_[type]` feature flags
- [core] Added the ability to rotate the Morio Root Token
- [ui] Added feature flag settings to the UI
- [core] Added new actions page including the UI to rotate the Root Token

**Fixed**

- [api] Fixed a thrown error in the `GET /token` endpoint due to passing in the wrong attibute
- [api] Implemented the `/kv/dump` endpoint (it always returned an empty object before)
- [api] Fixed incorrect node index in setup validation report
- [api] Allow scratch codes length in schema when validating OTP tokens
- [core] Fix an issue where the running services detection was not updated to reflect the container name prefix causing unneeded service restarts
- [ui] Guard against cluster leader being unknown in status view
- [ui] Show scratch codes after activating MFA on a local account

**Removed**

- We have discontinued support for AMI images and have removed the related documentation, configurations, and tools.
- [core] We no longer create broker topics on startup. Note that auto-create is enabled by default
