### PR TITLE
fix: Changes to `build:moriod-repo-deb` run script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `build:moriod-repo-deb` runscript after changes to the dbuilder container image in 0.5.4
+
 ## [0.5.4] - 2024-11-15
 
 ### Added

--- a/builders/dbuilder/entrypoint.sh
+++ b/builders/dbuilder/entrypoint.sh
@@ -56,6 +56,30 @@ build_repo_package() {
 }
 
 #
+# Build the Moriod repo Debian package
+#
+build_moriodrepo_package() {
+  cd /morio
+  mkdir -p pkg/DEBIAN
+  for FILE in control postinst; do
+    if [ -f $SRC/$FILE ]
+      then
+      echo "Copying $SRC/$FILE"
+      cp $SRC/$FILE pkg/DEBIAN/
+    fi
+  done
+
+  for DIRPATH in $SRC/*/; do
+    DIR=$(basename "$DIRPATH")
+    echo "Copying $DIR"
+    cp -R $SRC/$DIR pkg/
+  done
+
+  # Build the package
+  dpkg-deb --build pkg $DIST
+}
+
+#
 # Update the APT repository
 #
 update_apt_repo() {
@@ -128,7 +152,12 @@ elif [ $BUILD_JOB == "repo" ]; then
   build_repo_package
   echo "Updating repository"
   update_apt_repo
+elif [ $BUILD_JOB == "moriodrepo" ]; then
+  echo "Building moriod repo package for Debian"
+  SRC=/morio/src
+  DIST=/morio/dist
+  build_moriodrepo_package
 else
-  echo "Unknown build job, not running a build. Please specify 'client' or 'repo'"
+  echo "Unknown build job, not running a build. Please specify 'client', 'repo', or 'moriodrepo'"
 fi
 

--- a/scripts/build-repo-deb.sh
+++ b/scripts/build-repo-deb.sh
@@ -36,4 +36,4 @@ cp config/moriod-repos/deb/postinst build-context/
 docker run -it \
   -v ${MORIO_GIT_ROOT}/build-context:/morio/src \
   -v ${MORIO_GIT_ROOT}/data/data:/morio/dist \
-  itsmorio/dbuilder
+  itsmorio/dbuilder /entrypoint.sh moriodrepo


### PR DESCRIPTION
These changes were required after the changes made to the itsmorio/dbuilder entrypoint in v0.5.4

This changes only impacts the CI pipelines and post-release artifiact generation.