### PR TITLE
fix: Properly extract/inject processor settings

### DIFF
--- a/shared/src/utils.mjs
+++ b/shared/src/utils.mjs
@@ -53,7 +53,7 @@ export function reverseString (str) {
 }
 
 /**
- * Sleeps for a number of seconds in a async way
+ * Sleeps for a number of seconds in an async way
  *
  * This is a helper method to wait for a given amount of time
  * without blocking the even loop. This is typically used to

--- a/shared/src/utils.mjs
+++ b/shared/src/utils.mjs
@@ -1,4 +1,12 @@
 import { setTimeout } from 'node:timers/promises'
+import _get from 'lodash/get.js'
+import _set from 'lodash/set.js'
+
+/*
+ * Re-export these lodash helpers
+ */
+export const get = _get
+export const set = _set
 
 /**
  * Capitalize the first character of a string
@@ -18,6 +26,30 @@ export function capitalize(string) {
  */
 export function cloneAsPojo(obj) {
   return JSON.parse(JSON.stringify(obj))
+}
+
+/**
+ * A set helper that will only set if there's no value yet
+ *
+ * @param {object} obj - The object to mutate
+ * @param {string|array} path - The path/key to update
+ * @param {mixed} value - The value to set, if it is currently not set
+ * @return {obhect} obj - The mutated object
+ */
+export function setIfUnset(obj, path, val) {
+  if (typeof get(obj, path) === 'undefined') set(obj, path, val)
+
+  return obj
+}
+
+/**
+ * Reverses a string
+ *
+ * @param {string} str - The input string
+ * @return {string} rts - The reversed string
+ */
+export function reverseString (str) {
+  return str.split('').reverse().join('')
 }
 
 /**

--- a/ui/components/settings/navigation.mjs
+++ b/ui/components/settings/navigation.mjs
@@ -18,11 +18,7 @@ export const SettingsNavigation = ({
       .filter((entry) => !entry.hide)
       .map((entry) => (
         <li key={entry.id}>
-          <NavButton {...{ lead, entry, loadView, view, level }}>
-            <span className={`${entry.children ? 'uppercase font-bold' : 'capitalize'}`}>
-              {entry.title ? entry.title : entry.label}
-            </span>
-          </NavButton>
+          <NavButton {...{ lead, entry, loadView, view, level }} />
           {entry.children && (
             <SettingsNavigation
               {...{ view, loadView, mSettings }}
@@ -72,7 +68,7 @@ export const NavButton = ({
    */
   return (
     <button onClick={() => loadView([...lead, entry.id].join('/'))} className={className}>
-      {entry.title ? entry.title : entry.label}
+      {entry.title ? entry.title : entry.label ? entry.label : entry.id}
     </button>
   )
 }

--- a/ui/components/settings/templates/tap.mjs
+++ b/ui/components/settings/templates/tap.mjs
@@ -1,5 +1,6 @@
 import Joi from 'joi'
 import { BoolYesIcon, BoolNoIcon } from 'components/icons.mjs'
+import { Popout } from 'components/popout.mjs'
 
 /*
  * Tap (stream processing)
@@ -30,7 +31,7 @@ Refer to [the stream processing guide](https://morio.it/docs/guides/stream-proce
    * Basic structure for this template
    */
   const template = {
-    title: 'test',
+    title: 'Stream Processing',
     about: `Morio's __Tap__ service facilitates __stream processing__ of data flowing through a Morio collector.
 
 It abstracts the tricky parts of stream processing away,
@@ -50,20 +51,29 @@ Refer to [the stream processing guide](https://morio.it/docs/guides/stream-proce
    * Iterate over the tap handlers to add the children
    */
   for (const [name, conf] of Object.entries(dconf.tap)) {
-    const docs = conf.docs
+    const title = conf.title ? conf.title : name
+    const docs = conf.docs ? conf.docs : (
+      <Popout note>
+        <h4>This stream processor does not provide this info</h4>
+        <p>The <code>{name}</code> stream processor does not provide any <b>about</b> info.</p>
+      </Popout>
+    )
+    const href = conf.href
       ? [
-        `### Documentation`,
-        `The ${conf.title} documentation is available at: [${conf.docs}](${conf.docs}).`,
+        <Popout link>
+          <h5>Learn more about this stream processor</h5>
+          <a href={conf.href}>{conf.href}</a>
+        </Popout>
       ] : []
     const child = {
       type: 'form',
-      title: conf.title,
-      about: conf.about,
+      title,
+      docs,
       form: [
-        `### About the ${conf.title}`,
-        conf.about,
-        ...docs,
-        ...dynamicForm({ conf, dkey: name, mSettings, update }),
+        `### About`,
+        docs,
+        ...href,
+        ...dynamicForm({ conf, dkey: name, mSettings, update, name }),
       ]
     }
     template.children[name] = child
@@ -72,10 +82,47 @@ Refer to [the stream processing guide](https://morio.it/docs/guides/stream-proce
   return template
 }
 
-function dynamicForm ({ conf, dkey, mSettings, update }) {
+function dynamicForm ({ conf, dkey, mSettings, update, name }) {
   if (!conf.settings) return null
 
+  // Start the form
   const form = [ '### Settings' ]
+
+  // First, inject the enabled setting
+  if (typeof conf.settings?.enabled === 'undefined') {
+    const val = {
+      title: `Enable the ${name} stream processor`,
+      dflt: true,
+      type: 'list',
+      list: [
+        {
+          val: false,
+          label: 'Disabled',
+          about: `This completely disables the ${name} stream processor`
+        },
+        {
+          val: true,
+          label: 'Enabled',
+          about: `Enables the ${name} stream processor`
+        },
+      ]
+    }
+    form.push(...dynamicFormSetting('enabled', val, dkey, mSettings, update))
+  }
+
+  // Next, inject the topics setting in case it's a simple array
+  if (typeof conf.settings?.topics === 'undefined' || Array.isArray(conf.settings?.topics)) {
+    const val = {
+      title: 'List of topics to subscribe to',
+      dflt: conf.settings?.topics || [],
+      type: 'labels',
+    }
+    form.push(...dynamicFormSetting('topics', val, dkey, mSettings, update))
+    // Do not show this twice
+    if (conf.settings.topics) delete conf.settings.topics
+  }
+
+  // Now add the rest of the settings
   for (const [key, val] of Object.entries(conf.settings)) {
     form.push(...dynamicFormSetting(key, val, dkey, mSettings, update))
   }

--- a/ui/components/settings/templates/tap.mjs
+++ b/ui/components/settings/templates/tap.mjs
@@ -60,7 +60,7 @@ Refer to [the stream processing guide](https://morio.it/docs/guides/stream-proce
     )
     const href = conf.href
       ? [
-        <Popout link>
+        <Popout link key="popout">
           <h5>Learn more about this stream processor</h5>
           <a href={conf.href}>{conf.href}</a>
         </Popout>


### PR DESCRIPTION
Since we've added support for stream processors that you can add to Morio yourself, we also need to provide a way to manage their settings.

To keep boilerplate to a minumum, we do not require `enabled` to be set and accept a simple array for `topics` in addition to any other (full) configuration for settings.

These changes make that possible.