### PR TITLE
[core] feat: Adapt preseed loader to new overlay format

### DIFF
--- a/shared/src/loaders.mjs
+++ b/shared/src/loaders.mjs
@@ -5,8 +5,9 @@ import { Buffer } from 'node:buffer'
 import { simpleGit } from 'simple-git'
 import { hash } from './crypto.mjs'
 import { rm, mkdir, readFile, globDir } from './fs.mjs'
-import { cloneAsPojo, set, setIfUnset, reverseString } from './utils.mjs'
+import { cloneAsPojo, get, set, setIfUnset, reverseString } from './utils.mjs'
 import merge from 'lodash/merge.js'
+import unset from 'lodash/unset.js'
 
 /*
  * A collection of utils to load various files
@@ -632,7 +633,7 @@ function applyOverlays (settings, overlays, log) {
   for (const overlay of overlays) {
     i++
     log.debug(`Applying overlay ${i}/${count}`)
-    settings = applyOverlay(settings, overlay, log)
+    settings = applyOverlay(settings, overlay)
   }
 
   return settings
@@ -655,10 +656,9 @@ function applyOverlays (settings, overlays, log) {
  *
  * @param {object} settings - The settings object to mutate
  * @param {object} overlay - The overlay to apply
- * @param {object} log - The logger object
  * @return {object} settings - The mutated settings
  */
-function applyOverlay (settings, overlay={}, log) {
+function applyOverlay (settings, overlay={}) {
   // Merge goes first, this is the soft add for methods
   if (overlay.merge) {
     const todo = Array.isArray(overlay.merge) ? [...overlay.merge] : [overlay.merge]

--- a/shared/src/loaders.mjs
+++ b/shared/src/loaders.mjs
@@ -382,11 +382,11 @@ async function loadPreseedOverlays(preseed, gitroot, log) {
     }
   } else if (Array.isArray(preseed.overlays)) {
     /*
-     * If overlays holds and array, that array can still hold a glob pattern
+     * If overlays holds an array, that array can still hold a glob pattern.
      * Rather than duplicate the logic, we call this function recursively to
      * handle each array entry individually. To make that work, we just need
      * to adapt the preseed object a bit.
-     * Note that while this also happens to mean we support nested arrays
+     * Note that this also means we support nested arrays
      * although we don't tend to advocate for it. But it's possible.
      */
     for (const config of preseed.overlays) {
@@ -640,7 +640,7 @@ function applyOverlays (settings, overlays, log) {
 }
 
 /*
- * This function applies an overlay to the settings and returs them
+ * This function applies an overlay to the settings and returns them
  *
  * Overlays can contain 6 different keys, which are used to mutate the config.
  * They are:

--- a/shared/src/loaders.mjs
+++ b/shared/src/loaders.mjs
@@ -6,6 +6,7 @@ import { simpleGit } from 'simple-git'
 import { hash } from './crypto.mjs'
 import { rm, mkdir, readFile, globDir } from './fs.mjs'
 import { cloneAsPojo, set, setIfUnset, reverseString } from './utils.mjs'
+import merge from 'lodash/merge.js'
 
 /*
  * A collection of utils to load various files
@@ -189,19 +190,9 @@ export async function loadPreseededSettings(preseed, currentSettings=false, log,
   const overlays = await loadPreseedOverlays(preseed, gitroot, log)
 
   /*
-   * Now merge overlays into base settings
+   * Now merge overlays into base settings and return
    */
-  const count = overlays.length
-  let i = 0
-  for (const overlayConfig of overlays) {
-    i++
-    log.debug(`Loaded preseed overlay ${i}/${count}`)
-    for (const [path, value] of Object.entries(overlayConfig)) {
-      set(settings, path, value)
-    }
-  }
-
-  return settings
+  return applyOverlays(settings, overlays, log)
 }
 
 /**
@@ -320,11 +311,12 @@ async function loadPreseedFileFromUrl(config, log) {
  * @param {object|string} overlay - The preseed settings for this overlay
  * @param {object} preseed - The preseed settings
  * @param {string} gitroot - Path to the root where git repos are stored
+ * @param {object} log - The logger object
  * @return {object} settings - The loaded settings
  */
-async function loadPreseedOverlay(overlay, preseed, gitroot) {
+async function loadPreseedOverlay(overlay, preseed, gitroot, log) {
   if (typeof overlay === 'string') {
-    if (fromRepo(overlay)) return await loadPreseedFileFromRepo(overlay, preseed, gitroot)
+    if (fromRepo(overlay)) return await loadPreseedFileFromRepo(overlay, preseed, gitroot, log)
     const api = fromApi(overlay)
     if (api === 'github')
       return await loadPreseedFileFromGithub({
@@ -384,17 +376,21 @@ async function loadPreseedOverlays(preseed, gitroot, log) {
         if (overlay) overlays.push(overlay)
       }
     } else {
-      const overlay = await loadPreseedOverlay(preseed.overlays, preseed, gitroot)
+      const overlay = await loadPreseedOverlay(preseed.overlays, preseed, gitroot, log)
       if (overlay) overlays.push(overlay)
     }
   } else if (Array.isArray(preseed.overlays)) {
-
-  /*
-   * Handle array
-   */
+    /*
+     * If overlays holds and array, that array can still hold a glob pattern
+     * Rather than duplicate the logic, we call this function recursively to
+     * handle each array entry individually. To make that work, we just need
+     * to adapt the preseed object a bit.
+     * Note that while this also happens to mean we support nested arrays
+     * although we don't tend to advocate for it. But it's possible.
+     */
     for (const config of preseed.overlays) {
-      const overlay = await loadPreseedOverlay(config, preseed, gitroot)
-      if (overlay) overlays.push(overlay)
+      const sublays = await loadPreseedOverlays({ ...preseed, overlays: config }, gitroot, log)
+      if (sublays) overlays.push(...sublays)
     }
   }
 
@@ -630,3 +626,81 @@ function findPreseedTarget (file, root) {
   else return file.slice(-1 * start)
 }
 
+function applyOverlays (settings, overlays, log) {
+  const count = overlays.length
+  let i = 0
+  for (const overlay of overlays) {
+    i++
+    log.debug(`Applying overlay ${i}/${count}`)
+    settings = applyOverlay(settings, overlay, log)
+  }
+
+  return settings
+}
+
+/*
+ * This function applies an overlay to the settings and returs them
+ *
+ * Overlays can contain 6 different keys, which are used to mutate the config.
+ * They are:
+ * - merge: Soft-set a key in the settings object
+ * - ensure: Soft-add an element to an array in the settings object
+ * - push: Hard-add an element to an array in the settings object
+ * - drop: Hard-remove an element from an array in the settings object
+ * - set: Hard-set a key in the settings object
+ * - unset: Hard-unset a key in the settings object
+ *
+ * So we have 3 methods: soft-add, hard-add, and (hard-)remove
+ * and this both for objects and arrays.
+ *
+ * @param {object} settings - The settings object to mutate
+ * @param {object} overlay - The overlay to apply
+ * @param {object} log - The logger object
+ * @return {object} settings - The mutated settings
+ */
+function applyOverlay (settings, overlay={}, log) {
+  // Merge goes first, this is the soft add for methods
+  if (overlay.merge) {
+    const todo = Array.isArray(overlay.merge) ? [...overlay.merge] : [overlay.merge]
+    for (const item of todo) {
+      settings = merge({}, item, settings)
+    }
+  }
+  // Then we have the soft array method
+  if (overlay.ensure) {
+    for (const [path, val] of Object.entries(overlay.ensure)) {
+      const current = get(settings, path, [])
+      if (!current.includes(val)) set(settings, path, [...current, val])
+    }
+  }
+  // Then the hard array method to add
+  if (overlay.push) {
+    for (const [path, val] of Object.entries(overlay.ensure)) {
+      const current = get(settings, path, [])
+      set(settings, path, [...current, val])
+    }
+  }
+  // Then the hard array method to remove
+  if (overlay.drop) {
+    for (const [path, val] of Object.entries(overlay.ensure)) {
+      const current = get(settings, path, false)
+      if (Array.isArray(current) && current.includes(val)) {
+        set(settings, path, current.filter(item => item !== val))
+      }
+    }
+  }
+  // Set goes second to last, hard method to add
+  if (overlay.set) {
+    for (const [path, value] of Object.entries(overlay.set)) {
+      set(settings, path, value)
+    }
+  }
+  // Unset goes last, hard method to remove
+  if (overlay.unset) {
+    for (const [path, value] of Object.entries(overlay.unset)) {
+      unset(settings, path, value)
+    }
+  }
+
+  return settings
+}

--- a/shared/src/schema.mjs
+++ b/shared/src/schema.mjs
@@ -199,10 +199,19 @@ const preseed = Joi.alternatives().try(
     url: Joi.string(),
     git: Joi.object().pattern(Joi.string(), gitRepo),
     base: preseedFile,
-    overlays: Joi.array().items(preseedFile),
+    overlays: Joi.alternatives().try(
+      preseedFile,
+      Joi.array().items(preseedFile),
+    ),
     keys: preseedKeys,
-    processors: Joi.array().items(preseedFile),
-    modules: Joi.array().items(preseedFile),
+    processors: Joi.alternatives().try(
+      preseedFile,
+      Joi.array().items(preseedFile),
+    ),
+    modules: Joi.alternatives().try(
+      preseedFile,
+      Joi.array().items(preseedFile),
+    ),
   }),
   Joi.string()
 )

--- a/ui/components/settings/templates/tap.mjs
+++ b/ui/components/settings/templates/tap.mjs
@@ -52,7 +52,7 @@ Refer to [the stream processing guide](https://morio.it/docs/guides/stream-proce
    */
   for (const [name, conf] of Object.entries(dconf.tap)) {
     const title = conf.title ? conf.title : name
-    const docs = conf.docs ? conf.docs : (
+    const docs = conf.about ? conf.about : (
       <Popout note>
         <h4>This stream processor does not provide this info</h4>
         <p>The <code>{name}</code> stream processor does not provide any <b>about</b> info.</p>


### PR DESCRIPTION
These changes are in line with the new preseed file format that allows various operations, rather than merely setting certain values:

- `merge`: merges in an object, does not overwrite. Merge takes object (1 merge) or array (multiple)
- `ensure`: adds to array, but not if it is already there
- `push`: adds to an array even if it is there
- `drop`: removes from an array
- `set`: sets a value regardless of what is there
- `unset`: unset regardess of what is there