### PR TITLE
release: Morio v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2025-01-23
+
 ### Added
 
 - Started work on integration tests
@@ -32,7 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [ui] Added dashboarding (wip)
 - [ui] Added inventory views (wip)
 - [watcher] Added the `MORIO_IGNORE_CERTIFICATE_EXPIRY` escape hatch
-
 
 ### Changed
 

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morio/api",
-  "version": "0.6.0-rc.8",
+  "version": "0.6.0",
   "description": "Morio Management API",
   "private": true,
   "scripts": {

--- a/clients/morio/version/main.go
+++ b/clients/morio/version/main.go
@@ -1,3 +1,3 @@
 // This file is auto-generated
 package version
-var Version string = "0.6.0-rc.8"
+var Version string = "0.6.0"

--- a/config/package.json
+++ b/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morio/config",
-  "version": "0.6.0-rc.8",
+  "version": "0.6.0",
   "description": "Morio Configuration",
   "private": true,
   "scripts": {

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morio/core",
-  "version": "0.6.0-rc.8",
+  "version": "0.6.0",
   "description": "Morio Core",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morio",
-  "version": "0.6.0-rc.8",
+  "version": "0.6.0",
   "description": "Morio provides the plumbing for your observability needs",
   "license": "EUPL",
   "private": true,

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morio/shared",
-  "version": "0.6.0-rc.8",
+  "version": "0.6.0",
   "description": "Morio Library Methods for NodeJS (shared)",
   "private": true,
   "author": "CERT-EU <services@cert.europa.eu>",

--- a/ui/components/boards/checks.mjs
+++ b/ui/components/boards/checks.mjs
@@ -151,7 +151,6 @@ export const UpOrNot = ({ cacheKey, hideOnUp = false }) => {
     queryKey: [cacheKey],
     queryFn: () => {
       runCheckApiCall(api, cacheKey).then(result => {
-        console.log({result})
         if (result) setCache(result)
       })
     },

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.6.0-rc.8",
+  "version": "0.6.0",
   "private": true,
   "author": "CERT-EU <services@cert.europa.eu>",
   "license": "EUPL",

--- a/ui/pages/icons.mjs
+++ b/ui/pages/icons.mjs
@@ -7,7 +7,6 @@ const custom = {
 }
 
 const DashboardsPage = (props) => {
-  console.log(allIcons)
   return (
     <PageWrapper {...props}>
       <ContentWrapper {...props}>


### PR DESCRIPTION
This is Morio v0.6.0 :tada:

This is a minor release that includes a bunch of new features. We will cover them later in a blog post, for now, here is a list of changes:

**Added**

- Started work on integration tests
- Added the new `ENFORCE_SERVICE_CACH` feature flag
- [api] Added endpoints to read cache data
- [api] Added endpoints to manage the inventory
- [api] Added endpoints to retrieve flags and dynamic config
- [cache] Added the new cache service (ValKey)
- [connector] Added support for HTTP output
- [connector] Added support for LSCL input, filters, output, and pipelines
- [core] Support preseeding of client modules
- [core] Support preseeding of stream processors
- [core] Handle reseeding of client modules and stream processors
- [core] We now create ACL broker entries for tap service
- [db] Added tables for storing inventory data
- [tap] Added the new tap service for stream processing
- [ui] Added support for filters to the connector setting
- [ui] Added support for specifying input, output, or filter as an LSCL block
- [ui] Added support for writing a connector/logstash pipeline as raw LSCL
- [ui] Added support for HTTP input in connector settings
- [ui] Implemented the `DISABLE_SERVICE_UI` feature flag
- [ui] Added the `force_mrt` query parameter to force the sign in form to show the root token identity provider
- [ui] Added dashboarding (wip)
- [ui] Added inventory views (wip)
- [watcher] Added the `MORIO_IGNORE_CERTIFICATE_EXPIRY` escape hatch

**Changed**

- We renamed the `production` release channel to `stable`
- We removed all configuration that was handled differently for unit tests
- Our apt repositories are no longer tied to a specific (Debian) version
- [api] Remove anything done differently for unit tests
- [api] Persist test credentials to disk so tests can be re-run incrementally
- [client] The Morio client is now statically linked to improve portability
- [core] We no longer populate settings with all (disabled) feature flags
- [core] Remove anything done differently for unit tests
- [core] Persist test credentials to disk so tests can be re-run incrementally
- [core] Extended the moriod.env file to allow changing presets
- [shared] `mkdir` is now recursive
- [watcher] Added the cluster UUID to internal monitor IDs

**Fixed**

- [api] Handle browser domain mismatch in validation. [#109](https://github.com/certeu/morio/issues/109)
- [api] The `/up` endpoint is now anonymous and returns status 200 [#133](https://github.com/certeu/morio/issues/133)
- [api] RBAC would block access when a token in a cookie was expired, even if a valid Bearer token was provided
- [api] Update test run-script with prefixed container name
- [api] Required length for `api_key` and `api_key_secret` were inverted in the schema
- [broker] Respect broker log level set in preset rather than always use debug
- [ca] Prevent the CA service from restarting at every reload
- [core] Encrypt secrets when provided at initial setup. [#136](https://github.com/certeu/morio/issues/136)
- [core] Improve resilience when preseeding fails
- [core] Support tokens in preseed settings
- [client] Do not show help after restarting agents. [#101](https://github.com/certeu/morio/issues/101)
- [connector] Fixed a regression where the recent move to mTLS for Kafka broke the connector plugin
- [ui] Remove broken link from navigation. [#100](https://github.com/certeu/morio/issues/100)
- [ui] Handle new validation check for browser domain. [#109](https://github.com/certeu/morio/issues/109)
- [ui] Do not assume container images have tags. [#137](https://github.com/certeu/morio/issues/137)
- [watcher] Update internal hostnames with new Docker container prefix