### PR TITLE
[docs] fix: Broken links in documentation

### DIFF
--- a/docs/docs/guides/features/stream-processing/kafka/readme.mdx
+++ b/docs/docs/guides/features/stream-processing/kafka/readme.mdx
@@ -69,7 +69,7 @@ It does not handle things like graceful shutdown and so on.
 
 If you are not certain how to build upon this example, you might
 want to look at [our low-code stream processing
-solution](/docs/guides/settings/stream/tap/) instead.
+solution](/docs/guides/features/stream-processing/tap/) instead.
 :::
 
 ```js

--- a/docs/docs/guides/features/stream-processing/readme.mdx
+++ b/docs/docs/guides/features/stream-processing/readme.mdx
@@ -11,5 +11,5 @@ Stream processing in Morio can be handled in two different ways:
 
 Click on any of the links above to learn more. If you are not certain which is
 best for your use case, we recommend you start with [tap-based stream
-processing](/docs/guides/settings/stream/tap/).
+processing](/docs/guides/features/stream-processing/tap/).
 

--- a/docs/docs/guides/features/stream-processing/tap/readme.mdx
+++ b/docs/docs/guides/features/stream-processing/tap/readme.mdx
@@ -20,7 +20,7 @@ MorioHub](https://github.com/certeu/moriohub/tree/develop/processors) for
 inspiration.
 
 If you prefer another language, you can always handle these aspects yourself
-and [talk directly to Kafka](/docs/guides/settings/stream/kafka/).
+and [talk directly to Kafka](/docs/guides/features/stream-processing/kafka/).
 :::
 
 

--- a/docs/docs/guides/services/tap/readme.mdx
+++ b/docs/docs/guides/services/tap/readme.mdx
@@ -20,7 +20,7 @@ You write the logic of what to do with the data, and the tap service allows you 
 
 To learn more about stream processing in Morio, including how to create your
 own stream processor on top of the tap service, refer to [the stream processing
-guide](/docs/guides/settings/stream).
+guide](/docs/guides/features/stream-processing/).
 
 :::
 

--- a/docs/docs/reference/errors/morio.api.apikeys.list.failed/readme.mdx
+++ b/docs/docs/reference/errors/morio.api.apikeys.list.failed/readme.mdx
@@ -5,7 +5,7 @@ tags:
 
 ---
 <!-- MORIO_AUTO_GENERATED_CONTENT_STARTS - Manual changes made below will be overwritten skip-spellcheck -->
-__Unable to load the list of API keys from the database__ - When reaching out to the Morio database, we were unable to retrieve the data to complete this request.
+__Unable to load the list of API keys from the database__ - When reaching out to the Morio Database, we were unable to retrieve the data to complete this request.
 <!-- MORIO_AUTO_GENERATED_CONTENT_ENDS - Manual changes made above will be overwritten skip-spellcheck -->
 
 
@@ -17,7 +17,7 @@ __Unable to load the list of API keys from the database__ - When reaching out to
   "type": "https://morio.it/docs/reference/errors/morio.api.apikeys.list.failed",
   "status": 503,
   "title": "Unable to load the list of API keys from the database",
-  "detail": "When reaching out to the Morio database, we were unable to retrieve the data to complete this request."
+  "detail": "When reaching out to the Morio Database, we were unable to retrieve the data to complete this request."
 }
 ```
 <!-- MORIO_AUTO_GENERATED_CONTENT_ENDS - Manual changes made above will be overwritten skip-spellcheck -->

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "buildall:dev": "./scripts/run-build.sh dev",
     "buildall:testing": "./scripts/run-build.sh testing",
     "buildall:canary": "./scripts/run-build.sh canary",
-    "buildall:stable": "./scripts/run-build.sh testing",
+    "buildall:stable": "./scripts/run-build.sh stable",
     "build:api": "./scripts/build-container.sh api",
     "build:core": "./scripts/build-container.sh core",
     "build:clients": "./scripts/build-clients.sh",


### PR DESCRIPTION
Also includes copy/paste error fix in `package.json`