### PR TITLE
[tap] fix: Dockerfile and loader issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [tap] Reset npm environment in container to avoid npm issues
+
 ## [0.6.0] - 2025-01-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [tap] Reset npm environment in container to avoid npm issues
+- [tap] Missing comma in auto-generated stream processors module loader
 
 ## [0.6.0] - 2025-01-23
 

--- a/tap/Containerfile.stable
+++ b/tap/Containerfile.stable
@@ -24,7 +24,12 @@ COPY ./entrypoint-loader.mjs /entrypoint-loader.mjs
 RUN npm i
 
 ## Install esbuild & glob
-RUN npm install esbuild glob
+## This is some advance npm voodoo because we ran into trouble where
+## npm inside the container was not functioning well. Typically that
+## is not a problem since we do not need to install any dependencies
+## but it can be a real pain when troubleshooting, so this fixes that.
+## It essentially resets the environment, storing only HOME and USER.
+RUN env -i HOME="$HOME" PATH="$PATH" npm install --save-dev esbuild glob
 
 ## Install the pm2 process manager for NodeJS
 RUN npm install pm2 -g

--- a/tap/entrypoint-loader.mjs
+++ b/tap/entrypoint-loader.mjs
@@ -126,7 +126,7 @@ async function ensureModuleLoaders(settings) {
         const importName = module.replaceAll('-', '_')
         imports[processor][module] = {
           imp: `import ${importName} from './${filename}'`,
-          exp: `  "${module}": ${importName}`
+          exp: `  "${module}": ${importName},`
         }
       }
     }


### PR DESCRIPTION
This fixes two small issues with the Tap service:

-  Reset npm in container build. The npm inside the container was not behaving as expected, which makes troubleshooting hard. To remediate that, we reset the environment in the Dockerfile. Closes #177 
- Missing comma in auto-generated processor loader. Small mistake, but it prevents the tap service from building.