### PR TITLE
release: Morio v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [tap] The container will now report the correct name
 - [tap] Do not bundle stream processors inside the container image
 - [ui] Correctly display type in help messages in LSCL forms
-- [ui] Fixed broken links in breakcrumbs [#181](https://github.com/certeu/morio/issues/181)
+- [ui] Fixed broken links in breadcrumbs [#181](https://github.com/certeu/morio/issues/181)
 
 ## [0.6.0] - 2025-01-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2025-01-28
+
+### Added
+
+- [api] We now return the container tag and release channel from the status endpoint
+- [core] We now return the container tag and release channel from the status endpoint
+- [ui] Display the release channel on the status page
+
+### Changed
+
+- We now use the same container namespace in dev to prevent namespace squatting
+
 ### Fixed
 
 - [tap] Reset npm environment in container to avoid npm issues
 - [tap] Missing comma in auto-generated stream processors module loader
+- [tap] Add missing dependencies to container image
+- [tap] Fix volume mount for processors folder
+- [tap] The container will now report the correct name
+- [tap] Do not bundle stream processors inside the container image
+- [ui] Correctly display type in help messages in LSCL forms
+- [ui] Fixed broken links in breakcrumbs [#181](https://github.com/certeu/morio/issues/181)
 
 ## [0.6.0] - 2025-01-23
 

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itsmorio/api",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Morio Management API",
   "private": true,
   "scripts": {

--- a/api/package.json
+++ b/api/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@morio/api",
+  "name": "@itsmorio/api",
   "version": "0.6.0",
   "description": "Morio Management API",
   "private": true,

--- a/api/src/lib/utils.mjs
+++ b/api/src/lib/utils.mjs
@@ -34,9 +34,10 @@ const store = new Store(log)
   .set('prefix', getPreset('MORIO_API_PREFIX'))
   .set('info', {
     about: 'Morio Management API',
-    name: '@morio/api',
+    channel: getPreset('MORIO_RELEASE_CHANNEL'),
+    name: '@itsmorio/api',
     production: inProduction(),
-    version: getPreset('MORIO_VERSION'),
+    version: getPreset('MORIO_CONTAINER_TAG'),
   })
 
 /*

--- a/clients/morio/version/main.go
+++ b/clients/morio/version/main.go
@@ -1,3 +1,3 @@
 // This file is auto-generated
 package version
-var Version string = "0.6.0"
+var Version string = "0.6.1"

--- a/config/package.json
+++ b/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itsmorio/config",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Morio Configuration",
   "private": true,
   "scripts": {

--- a/config/package.json
+++ b/config/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@morio/config",
+  "name": "@itsmorio/config",
   "version": "0.6.0",
   "description": "Morio Configuration",
   "private": true,

--- a/config/presets.mjs
+++ b/config/presets.mjs
@@ -109,6 +109,12 @@ presets.MORIO_ERRORS_WEB_PREFIX = 'https://morio.it/docs/reference/errors/'
 predocs.MORIO_CONTAINER_PREFIX = "Prefix used in container images for Morio"
 presets.MORIO_CONTAINER_PREFIX = "morio-"
 
+predocs.MORIO_CONTAINER_TAG = "The currently running container tag. Picked up from environment variables."
+presets.MORIO_CONTAINER_TAG = "dev-build"
+
+predocs.MORIO_RELEASE_CHANNEL = "The current release channel. Picked up from environment variables."
+presets.MORIO_RELEASE_CHANNEL = "dev"
+
 /*
  * Docker presets
  */

--- a/config/services/api.mjs
+++ b/config/services/api.mjs
@@ -62,8 +62,8 @@ export const resolveServiceConfiguration = ({ utils }) => {
     container: {
       // Name to use for the running container
       container_name: 'api',
-      // Image to run (different in dev)
-      image: PROD ? 'itsmorio/api' : 'devmorio/api',
+      // Image to run
+      image: 'itsmorio/api',
       // Image tag (version) to run
       tag: utils.getPreset('MORIO_VERSION_TAG') + getContainerTagSuffix(utils),
       // Don't attach to the default network

--- a/config/services/core.mjs
+++ b/config/services/core.mjs
@@ -25,7 +25,7 @@ export const resolveServiceConfiguration = ({ utils }) => {
       // Name to use for the running container
       container_name: 'core',
       // Image to run (different in dev)
-      image: PROD ? 'itsmorio/core' : utils.isUnitTest() ? 'testmorio/core' : 'devmorio/core',
+      image: 'itsmorio/core',
       // Image tag (version) to run
       tag: utils.getPreset('MORIO_VERSION_TAG') + getContainerTagSuffix(utils),
       // Don't attach to the default network

--- a/config/services/tap.mjs
+++ b/config/services/tap.mjs
@@ -11,8 +11,8 @@ export const resolveServiceConfiguration = ({ utils }) => {
 
   return {
     container: {
-      // Image to run (different in dev)
-      image: PROD ? 'itsmorio/tap' : 'devmorio/tap',
+      // Image to run
+      image: 'itsmorio/tap',
       // Image tag (version) to run
       tag: utils.getPreset('MORIO_VERSION_TAG') + getContainerTagSuffix(utils),
       // Name to use for the running container

--- a/config/services/tap.mjs
+++ b/config/services/tap.mjs
@@ -27,6 +27,7 @@ export const resolveServiceConfiguration = ({ utils }) => {
       volumes: PROD
         ? [
             `${utils.getPreset('MORIO_CONFIG_ROOT')}/tap:/morio/tap/config`,
+            `${utils.getPreset('MORIO_CONFIG_ROOT')}/tap/processors:/morio/tap/processors`,
           ]
         : [
             `${utils.getPreset('MORIO_GIT_ROOT')}:/morio`,

--- a/config/services/ui.mjs
+++ b/config/services/ui.mjs
@@ -19,8 +19,8 @@ export const resolveServiceConfiguration = ({ utils }) => {
     container: {
       // Name to use for the running container
       container_name: 'ui',
-      // Image to run (different in dev)
-      image: PROD ? 'itsmorio/ui' : 'devmorio/ui',
+      // Image to run
+      image: 'itsmorio/ui',
       // Image tag (version) to run
       tag: utils.getPreset('MORIO_VERSION_TAG') + getContainerTagSuffix(utils),
       // Don't attach to the default network

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itsmorio/core",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Morio Core",
   "private": true,
   "scripts": {

--- a/core/package.json
+++ b/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@morio/core",
+  "name": "@itsmorio/core",
   "version": "0.6.0",
   "description": "Morio Core",
   "private": true,

--- a/core/src/lib/utils.mjs
+++ b/core/src/lib/utils.mjs
@@ -37,9 +37,10 @@ const store = new Store(log)
   .set('state.ephemeral', true)
   .set('info', {
     about: 'Morio Core',
-    name: '@morio/core',
+    channel: getPreset('MORIO_RELEASE_CHANNEL'),
+    name: '@itsmorio/core',
     production: inProduction(),
-    version: getPreset('MORIO_VERSION'),
+    version: getPreset('MORIO_CONTAINER_TAG'),
   })
 
 /*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "morio",
-  "version": "0.6.0-rc.8",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "morio",
-      "version": "0.6.0-rc.8",
+      "version": "0.6.0",
       "license": "EUPL",
       "workspaces": [
         "api",
@@ -41,7 +41,7 @@
     },
     "api": {
       "name": "@morio/api",
-      "version": "0.6.0-rc.8",
+      "version": "0.6.0",
       "license": "EUPL",
       "dependencies": {
         "@otplib/preset-default": "^12.0.1",
@@ -93,7 +93,7 @@
     },
     "config": {
       "name": "@morio/config",
-      "version": "0.6.0-rc.8",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "bson": "^6.8.0",
@@ -103,7 +103,7 @@
     },
     "core": {
       "name": "@morio/core",
-      "version": "0.6.0-rc.8",
+      "version": "0.6.0",
       "license": "EUPL",
       "dependencies": {
         "axios": "^1.7.7",
@@ -7682,9 +7682,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -29404,7 +29404,7 @@
     },
     "shared": {
       "name": "@morio/shared",
-      "version": "0.6.0-rc.8",
+      "version": "0.6.0",
       "license": "EUPL",
       "dependencies": {
         "bson": "^6.8.0",
@@ -29437,10 +29437,12 @@
       "version": "0.5.5",
       "license": "EUPL",
       "dependencies": {
+        "axios": "^1.7.9",
         "esbuild": "^0.24.0",
         "ioredis": "^5.4.1",
         "ipaddr.js": "^2.2.0",
         "kafkajs": "^2.2.4",
+        "lodash": "^4.17.21",
         "pino": "^9.5.0"
       },
       "devDependencies": {
@@ -29880,7 +29882,7 @@
       }
     },
     "ui": {
-      "version": "0.6.0-rc.8",
+      "version": "0.6.0",
       "license": "EUPL",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morio",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Morio provides the plumbing for your observability needs",
   "license": "EUPL",
   "private": true,

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -47,8 +47,8 @@ else
     echo ""
     RELEASE_CHANNEL="dev"
     RELEASE_CHANNEL_TAG="dev"
-    NAMESPACE="devmorio"
-    TAG_SUFFIX=""
+    NAMESPACE="itsmorio"
+    TAG_SUFFIX="-dev"
   fi
 fi
 
@@ -64,7 +64,12 @@ else
 
   # If building core, build the clients first
   if [[ "$CONTAINER" == "core" ]]; then
-    npm run build:clients
+    # But not for dev
+    if [[ "$RELEASE_CHANNEL" == "dev" ]]; then
+      echo "Skipping client build for dev"
+    else
+      npm run build:clients
+    fi
   fi
 
   # Keep coverage reports out of the build

--- a/scripts/json-loader.mjs
+++ b/scripts/json-loader.mjs
@@ -13,6 +13,7 @@ import api from '../api/package.json' assert { type: 'json' }
 import config from '../config/package.json' assert { type: 'json' }
 import core from '../core/package.json' assert { type: 'json' }
 import shared from '../shared/package.json' assert { type: 'json' }
+import tap from '../tap/package.json' assert { type: 'json' }
 import ui from '../ui/package.json' assert { type: 'json' }
 
-export { root, api, config, core, shared, ui }
+export { root, api, config, core, shared, tap, ui }

--- a/scripts/reversion.mjs
+++ b/scripts/reversion.mjs
@@ -4,7 +4,7 @@ import readline from 'node:readline'
 import process from 'node:process'
 import mustache from 'mustache'
 // Load various package.json files
-import { root, api, config, core, shared, ui } from './json-loader.mjs'
+import { root, api, config, core, shared, tap, ui } from './json-loader.mjs'
 
 /*
  * Object holding all files we need to update and their folder
@@ -15,6 +15,7 @@ const files = {
   config,
   core,
   shared,
+  tap,
   ui,
 }
 

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@morio/shared",
+  "name": "@itsmorio/shared",
   "version": "0.6.0",
   "description": "Morio Library Methods for NodeJS (shared)",
   "private": true,

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itsmorio/shared",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Morio Library Methods for NodeJS (shared)",
   "private": true,
   "author": "CERT-EU <services@cert.europa.eu>",

--- a/tap/Containerfile.stable
+++ b/tap/Containerfile.stable
@@ -30,6 +30,11 @@ RUN env -i HOME="$HOME" PATH="$PATH" npm install
 ## Install the pm2 process manager for NodeJS
 RUN npm install pm2 -g
 
+## Ensure the processors folder exist
+## But do not bundle any processors if it does
+RUN mkdir -p /morio/tap/processors
+RUN rm -f /morio/tap/processors/*
+
 ## Add a morio user to run the NodeJS code
 RUN addgroup --system --gid ${GID:-2112} ${USER:-morio} \
   && adduser --system --uid ${UID:-2112} --gid ${GIS:-2112} --gecos "Morio User" --home=/home/morio ${USER:-morio} \

--- a/tap/Containerfile.stable
+++ b/tap/Containerfile.stable
@@ -20,16 +20,12 @@ COPY . .
 COPY ./entrypoint.sh /entrypoint.sh
 COPY ./entrypoint-loader.mjs /entrypoint-loader.mjs
 
-## Install dependencies
-RUN npm i
-
-## Install esbuild & glob
 ## This is some advance npm voodoo because we ran into trouble where
 ## npm inside the container was not functioning well. Typically that
 ## is not a problem since we do not need to install any dependencies
 ## but it can be a real pain when troubleshooting, so this fixes that.
 ## It essentially resets the environment, storing only HOME and USER.
-RUN env -i HOME="$HOME" PATH="$PATH" npm install --save-dev esbuild glob
+RUN env -i HOME="$HOME" PATH="$PATH" npm install
 
 ## Install the pm2 process manager for NodeJS
 RUN npm install pm2 -g

--- a/tap/package.json
+++ b/tap/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@morio/tap",
+  "name": "@itsmorio/tap",
   "version": "0.5.5",
   "description": "Morio Tap",
   "private": true,

--- a/tap/package.json
+++ b/tap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itsmorio/tap",
-  "version": "0.5.5",
+  "version": "0.6.1",
   "description": "Morio Tap",
   "private": true,
   "scripts": {

--- a/tap/package.json
+++ b/tap/package.json
@@ -12,10 +12,12 @@
     "prettier": "npx prettier --ignore-unknown --write ."
   },
   "dependencies": {
+    "axios": "^1.7.9",
     "esbuild": "^0.24.0",
     "ioredis": "^5.4.1",
     "ipaddr.js": "^2.2.0",
     "kafkajs": "^2.2.4",
+    "lodash": "^4.17.21",
     "pino": "^9.5.0"
   },
   "imports": {

--- a/ui/components/settings/templates/connector/lscl.mjs
+++ b/ui/components/settings/templates/connector/lscl.mjs
@@ -19,7 +19,7 @@ const nl = "\n"
 const t = "  "
 
 const examples = {
-  input: (t1='') => `{${t1}exec {${nl + t1 + t}command => "echo 'hi!'"${nl + t1 + t}interval => 30${nl + t1}}`,
+  input: (t1='') => `${t1}exec {${nl + t1 + t}command => "echo 'hi!'"${nl + t1 + t}interval => 30${nl + t1}}`,
   filter: (t1='') => `${t1}mutate {${nl + t1 + t}add_field => {${nl + t1 + t + t}"sourcetype" => "_json"${nl + t1 + t}}${nl + t1}}`,
   output: (t1='') => `${t1}sink { }`,
 }
@@ -50,11 +50,11 @@ const lsclForm = (type) => ({
         Metadata: xputMeta('filter'),
         Configuration: [
          {
-           schema: Joi.boolean().default(false).label('Wrap as filter'),
-           label: 'Wrap LSCL in a filter block',
+           schema: Joi.boolean().default(false).label('Wrap as input'),
+           label: `Wrap LSCL in a ${type} block`,
            labelBL: data?.wrap
-             ? <>We will wrap your LSCL code in a filter block: <code>{`filter { [your LSCL here] }`}</code></>
-             : 'We will use your LSCL code as-is. You can use this to bundle multiple filter steps.',
+             ? <>Enable this to wrap your LSCL code in a {type} block: <code>{`${type} { ... }`}</code></>
+             : 'Disable this to use your LSCL code as-is in the pipeline.',
            list: [true, false],
            labels: ['Yes', 'No'],
            dflt: true,

--- a/ui/components/settings/templates/connector/lscl.mjs
+++ b/ui/components/settings/templates/connector/lscl.mjs
@@ -50,7 +50,7 @@ const lsclForm = (type) => ({
         Metadata: xputMeta('filter'),
         Configuration: [
          {
-           schema: Joi.boolean().default(false).label('Wrap as input'),
+           schema: Joi.boolean().default(false).label(`Wrap as ${type}`),
            label: `Wrap LSCL in a ${type} block`,
            labelBL: data?.wrap
              ? <>Enable this to wrap your LSCL code in a {type} block: <code>{`${type} { ... }`}</code></>

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ui",
+  "name": "itsmorio/ui",
   "version": "0.6.0",
   "private": true,
   "author": "CERT-EU <services@cert.europa.eu>",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "itsmorio/ui",
+  "name": "@itsmorio/ui",
   "version": "0.6.1",
   "private": true,
   "author": "CERT-EU <services@cert.europa.eu>",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itsmorio/ui",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "author": "CERT-EU <services@cert.europa.eu>",
   "license": "EUPL",

--- a/ui/pages/boards/logs/[host]/index.mjs
+++ b/ui/pages/boards/logs/[host]/index.mjs
@@ -7,7 +7,7 @@ import { Uuid } from 'components/uuid.mjs'
 export default function DashboardsHostLogsPage ({ host }) {
   const meta = {
     title: 'Cached host logs',
-    page: ['dashboards', 'logs', <Uuid key="uuid" uuid={host}/>],
+    page: ['boards', 'logs', <Uuid key="uuid" uuid={host}/>],
     Icon: LogsIcon
   }
 

--- a/ui/pages/boards/logs/show/[cachekey].mjs
+++ b/ui/pages/boards/logs/show/[cachekey].mjs
@@ -6,7 +6,7 @@ import { ShowLogs } from 'components/boards/logs.mjs'
 export default function DashboardsShowLogsPage ({ cachekey }) {
   const meta = {
     title: 'Show cached logs',
-    page: ['dashboards', 'logs', 'show', <span key='ck' className="font-mono">{cachekey}</span>],
+    page: ['boards', 'logs', 'show', <span key='ck' className="font-mono">{cachekey}</span>],
     Icon: LogsIcon
   }
 

--- a/ui/pages/status/index.mjs
+++ b/ui/pages/status/index.mjs
@@ -39,7 +39,7 @@ const ClusterInfo = ({ status }) => {
 
   return (
     <div className={`p-2 px-4 flex flex-row items-center gap-2`}>
-      <b className={``}>Morio v{status.core.info.version}</b>
+      Morio <b>{status.core.info.version}</b> (<b>{status.core.info.channel}</b> channel)
       on
       <b>{node}</b>
       {node === leader ? (


### PR DESCRIPTION
This is a patch release, with mostly fixes for the new tap service.

**Added**

- [api] We now return the container tag and release channel from the status endpoint
- [core] We now return the container tag and release channel from the status endpoint
- [ui] Display the release channel on the status page

**Changed**

- We now use the same container namespace in dev to prevent namespace squatting

**Fixed**

- [tap] Reset npm environment in container to avoid npm issues
- [tap] Missing comma in auto-generated stream processors module loader
- [tap] Add missing dependencies to container image
- [tap] Fix volume mount for processors folder
- [tap] The container will now report the correct name
- [tap] Do not bundle stream processors inside the container image
- [ui] Correctly display type in help messages in LSCL forms
- [ui] Fixed broken links in breakcrumbs [#181](https://github.com/certeu/morio/issues/181)