### PR TITLE
release: v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2025-02-04
+
 ### Added
 
 - Added support for preseeding chart plugins

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itsmorio/api",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Morio Management API",
   "private": true,
   "scripts": {
@@ -41,6 +41,7 @@
     "kafkajs": "^2.2.4",
     "lodash": "^4.17.21",
     "minimatch": "^10.0.1",
+    "mustache": "^4.2.0",
     "node-forge": "^1.3.1",
     "node-jose": "^2.2.0",
     "openid-client": "^5.7.0",

--- a/clients/morio/version/main.go
+++ b/clients/morio/version/main.go
@@ -1,3 +1,3 @@
 // This file is auto-generated
 package version
-var Version string = "0.6.1"
+var Version string = "0.6.2"

--- a/config/package.json
+++ b/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itsmorio/config",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Morio Configuration",
   "private": true,
   "scripts": {

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itsmorio/core",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Morio Core",
   "private": true,
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "morio",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "morio",
-      "version": "0.6.0",
+      "version": "0.6.2",
       "license": "EUPL",
       "workspaces": [
         "api",
@@ -40,8 +40,8 @@
       }
     },
     "api": {
-      "name": "@morio/api",
-      "version": "0.6.0",
+      "name": "@itsmorio/api",
+      "version": "0.6.2",
       "license": "EUPL",
       "dependencies": {
         "@otplib/preset-default": "^12.0.1",
@@ -60,6 +60,7 @@
         "kafkajs": "^2.2.4",
         "lodash": "^4.17.21",
         "minimatch": "^10.0.1",
+        "mustache": "^4.2.0",
         "node-forge": "^1.3.1",
         "node-jose": "^2.2.0",
         "openid-client": "^5.7.0",
@@ -92,8 +93,8 @@
       }
     },
     "config": {
-      "name": "@morio/config",
-      "version": "0.6.0",
+      "name": "@itsmorio/config",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "bson": "^6.8.0",
@@ -102,8 +103,8 @@
       }
     },
     "core": {
-      "name": "@morio/core",
-      "version": "0.6.0",
+      "name": "@itsmorio/core",
+      "version": "0.6.2",
       "license": "EUPL",
       "dependencies": {
         "axios": "^1.7.7",
@@ -4866,6 +4867,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/@itsmorio/api": {
+      "resolved": "api",
+      "link": true
+    },
+    "node_modules/@itsmorio/config": {
+      "resolved": "config",
+      "link": true
+    },
+    "node_modules/@itsmorio/core": {
+      "resolved": "core",
+      "link": true
+    },
+    "node_modules/@itsmorio/shared": {
+      "resolved": "shared",
+      "link": true
+    },
+    "node_modules/@itsmorio/tap": {
+      "resolved": "tap",
+      "link": true
+    },
+    "node_modules/@itsmorio/ui": {
+      "resolved": "ui",
+      "link": true
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -5083,26 +5108,6 @@
         "@types/react": ">=16",
         "react": ">=16"
       }
-    },
-    "node_modules/@morio/api": {
-      "resolved": "api",
-      "link": true
-    },
-    "node_modules/@morio/config": {
-      "resolved": "config",
-      "link": true
-    },
-    "node_modules/@morio/core": {
-      "resolved": "core",
-      "link": true
-    },
-    "node_modules/@morio/shared": {
-      "resolved": "shared",
-      "link": true
-    },
-    "node_modules/@morio/tap": {
-      "resolved": "tap",
-      "link": true
     },
     "node_modules/@n8tb1t/use-scroll-position": {
       "version": "2.0.3",
@@ -27725,10 +27730,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/ui": {
-      "resolved": "ui",
-      "link": true
-    },
     "node_modules/uid-safe": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
@@ -29403,8 +29404,8 @@
       }
     },
     "shared": {
-      "name": "@morio/shared",
-      "version": "0.6.0",
+      "name": "@itsmorio/shared",
+      "version": "0.6.2",
       "license": "EUPL",
       "dependencies": {
         "bson": "^6.8.0",
@@ -29412,6 +29413,7 @@
         "jsonwebtoken": "^9.0.2",
         "lodash": "^4.17.21",
         "minimatch": "^10.0.1",
+        "mustache": "^4.2.0",
         "node-forge": "^1.3.1",
         "node-jose": "^2.2.0",
         "openpgp": "^5.11.2"
@@ -29433,8 +29435,8 @@
       }
     },
     "tap": {
-      "name": "@morio/tap",
-      "version": "0.5.5",
+      "name": "@itsmorio/tap",
+      "version": "0.6.2",
       "license": "EUPL",
       "dependencies": {
         "axios": "^1.7.9",
@@ -29882,7 +29884,8 @@
       }
     },
     "ui": {
-      "version": "0.6.0",
+      "name": "@itsmorio/ui",
+      "version": "0.6.2",
       "license": "EUPL",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morio",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Morio provides the plumbing for your observability needs",
   "license": "EUPL",
   "private": true,

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itsmorio/shared",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Morio Library Methods for NodeJS (shared)",
   "private": true,
   "author": "CERT-EU <services@cert.europa.eu>",

--- a/tap/package.json
+++ b/tap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itsmorio/tap",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Morio Tap",
   "private": true,
   "scripts": {

--- a/ui/components/settings/templates/connector/lscl.mjs
+++ b/ui/components/settings/templates/connector/lscl.mjs
@@ -36,7 +36,7 @@ const lsclForm = (type) => ({
   title: 'LSCL',
   about: `Write a custom ${type} in LSCL`,
   desc: `Use this if Morio does not provide a preconfigured ${type} for your use case.`,
-  local: (data) => `connector.filters.${data.id}`,
+  local: (data) => `connector.${type}s.${data.id}`,
   form: ({ data }) => [
     <Popout tip key="tip">
       <b>LSCL</b> is the <b>L</b>og<b>S</b>tash <b>C</b>onfiguration <b>L</b>anguage. It is

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itsmorio/ui",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "author": "CERT-EU <services@cert.europa.eu>",
   "license": "EUPL",


### PR DESCRIPTION
Changelog since v0.6.1:

**Added**

- Added support for preseeding chart plugins
- [api] Return host name/fqdn when loading inventory data
- [api] Added a new endpoint to read (only) the hostname/fqdn from the inventory
- [ui] Allow overriding certain UI aspects by setting KV keys
- [ui] Add KV management to tools pages
- [ui] Group operating systems on inventory pages
- [ui] Improvement to inventory pages

**Changed**

- [ui] Style tweaks
- [ui] Use brand color for dark mode background

**Fixed**

- [ui] Add missing inventory/oss icon to main navigation menu
- [tap] Fix an issue with metrics caching expiry
- [dbuilder] Fix incorrect tagging of container image
- [rbuilder] Fix incorrect tagging of container image