### PR TITLE
feat: Flanking services configuration in UI and orchestration

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,3 +8,4 @@ Containerfile
 json-loader.mjs
 control
 postinst
+pm2.*.config.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [api] Don't block preseeding due to IP validation
 - [api] Fix incorrect handling of clients vars on push
 - [api] Do not use key as table field when storing apikeys
+- [api] Fix an issue in IP resolver validation
 - [client] Continue reset command even if files are missing
 - [tap] Prevent populated loader files from being included on build images
 - [tap] Fix issue with concatenation of charts logic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [ui] Add support for enabling Moriohub integration in the setup wizard
 
+### Changed
+
+- [api] Run in PM2 and restart when memory exceeds 250MB
+- [core] Run in PM2 and restart when memory exceeds 250MB
+
 ### Fixed
 
 - [api] Don't block preseeding due to IP validation
 - [api] Fix incorrect handling of clients vars on push
 - [api] Do not use key as table field when storing apikeys
 - [api] Fix an issue in IP resolver validation
+- [api] Fix an issue in flanking node validation
 - [client] Continue reset command even if files are missing
 - [tap] Prevent populated loader files from being included on build images
 - [tap] Fix issue with concatenation of charts logic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [ui] Add UI to manage flanking nodes and services
+- [core] Add selective deployment of flanking services
+
+### Changed
+
+- Allow users to define where to run flanking services
+- [api] Run in PM2 and restart when memory exceeds 250MB
+- [core] Run in PM2 and restart when memory exceeds 250MB
+- [core] Cluster join/heartbeat changes for flanking nodes
+
+### Fixed
+
+- [api] Fix an issue in IP resolver validation
+- [api] Fix an issue in flanking node validation
+
 ## [0.8.1] - 2025-03-12
 
 ### Added
 
 - [ui] Add support for enabling Moriohub integration in the setup wizard
 
-### Changed
-
-- [api] Run in PM2 and restart when memory exceeds 250MB
-- [core] Run in PM2 and restart when memory exceeds 250MB
-
 ### Fixed
 
 - [api] Don't block preseeding due to IP validation
 - [api] Fix incorrect handling of clients vars on push
 - [api] Do not use key as table field when storing apikeys
-- [api] Fix an issue in IP resolver validation
-- [api] Fix an issue in flanking node validation
 - [client] Continue reset command even if files are missing
 - [tap] Prevent populated loader files from being included on build images
 - [tap] Fix issue with concatenation of charts logic

--- a/api/Containerfile.dev
+++ b/api/Containerfile.dev
@@ -7,6 +7,9 @@ WORKDIR /morio/api
 # Add curl as it's used in the test run to detect when the API comes up
 RUN apt-get update && apt install curl ncat git -y
 
+## Install the pm2 process manager for NodeJS
+RUN npm install pm2 -g
+
 ## Add a morio user to run the NodeJS code
 RUN addgroup --system --gid ${GID:-2112} ${USER:-morio} \
   && adduser --system --uid ${UID:-2112} --gid ${GIS:-2112} --gecos "Morio User" --home=/home/morio ${USER:-morio}

--- a/api/Containerfile.stable
+++ b/api/Containerfile.stable
@@ -41,9 +41,4 @@ COPY --from=builder /morio/api/dist/index.mjs ./dist/index.mjs
 
 ## Drop privleges and run NodeJS code via pm2
 USER ${USER:-morio}
-CMD [ "pm2-runtime", \
-  "--name", "api", \
-  "--namespace", "morio", \
-  "--log-type", "json", \
-  "--max-memory-bytes", "250000000", \
-  "./dist/index.mjs" ]
+CMD [ "pm2-runtime", "start", "/etc/morio/api/pm2.config.js" ]

--- a/api/package.json
+++ b/api/package.json
@@ -7,7 +7,7 @@
     "build": "node build.mjs",
     "vbuild": "MORIO_ESBUILD_VERBOSE=1 node build.mjs",
     "clean": "rimraf dist",
-    "dev": "NODE_ENV=development nodemon src/index.mjs --no-warnings",
+    "dev": "NODE_ENV=development pm2-runtime start /etc/morio/api/pm2.config.js",
     "lint": "eslint --fix 'src/**' 'openapi/**' 'config/**' 'shared/**' 'tests/**' 'openapi/**'",
     "prettier": "npx prettier --ignore-unknown --write .",
     "test": "../scripts/testcheck.sh && docker exec -it -e \"MORIO_FQDN=${MORIO_FQDN}\" morio-api node --no-warnings --test-concurrency=1 --test",

--- a/api/src/lib/validate-settings.mjs
+++ b/api/src/lib/validate-settings.mjs
@@ -60,7 +60,7 @@ export async function validateSettings(newSettings, headers = false) {
     newSettings.cluster.flanking_nodes &&
     (!Array.isArray(newSettings.cluster.flanking_nodes) ||
       newSettings.cluster.flanking_nodes.length < 0 ||
-      newSettings.cluster.flanking_nodes.length < 36)
+      newSettings.cluster.flanking_nodes.length > 35)
   ) {
     report.info.push(`Settings are not valid`)
     report.errors.push(`Flanking node count is not supported`)

--- a/config/index.mjs
+++ b/config/index.mjs
@@ -3,6 +3,7 @@ import {
   serviceOrder,
   ephemeralServiceOrder,
   optionalServices,
+  hookMsg,
 } from './services/index.mjs'
 import { presets, getPreset, inProduction, loadAllPresets } from './presets.mjs'
 import { pullConfig } from './pull-oci.mjs'
@@ -16,5 +17,6 @@ export {
   serviceOrder,
   ephemeralServiceOrder,
   optionalServices,
+  hookMsg,
   pullConfig,
 }

--- a/config/services/api.mjs
+++ b/config/services/api.mjs
@@ -105,5 +105,19 @@ export const resolveServiceConfiguration = ({ utils }) => {
      * Traefik (proxy) configuration for the API service
      */
     traefik,
+    /*
+     * PM2 (node process manager) configuration
+     */
+    pm2: {
+      apps: [
+        {
+          name: "api",
+          script: PROD ? "./dist/index.mjs" : "./src/index.mjs",
+          cwd: "/morio/api",
+          max_memory_restart: "250M",
+          watch: PROD ? false : ['./src'],
+        }
+      ]
+    }
   }
 }

--- a/config/services/index.mjs
+++ b/config/services/index.mjs
@@ -152,3 +152,18 @@ export function getContainerTagSuffix({ getPreset }) {
 
   return CHANNEL === 'stable' ? '' : `-${CHANNEL}`
 }
+
+export const hookMsg = {
+  ok: {
+    wanted: 'Service is wanted',
+    recreate: 'Service needs to be recreated',
+    restart: 'Service needs to be restarted',
+    reload: 'Service needs to be reloaded',
+  },
+  ko: {
+    wanted: 'Service is not wanted',
+    recreate: 'Service does not need to be recreated',
+    restart: 'Service does not need to be restarted',
+    reload: 'Service does not need to be reloaded',
+  }
+}

--- a/core/.eslintignore
+++ b/core/.eslintignore
@@ -8,3 +8,5 @@ run-unit-tests.sh
 *.md
 control
 postinst
+pm2.*.config.js
+

--- a/core/Containerfile.dev
+++ b/core/Containerfile.dev
@@ -7,5 +7,8 @@ WORKDIR /morio/core
 # Add curl as it's used in the test run to detect when the API comes up
 RUN apt-get update && apt install curl git -y
 
+## Install the pm2 process manager for NodeJS
+RUN npm install pm2 -g
+
 ## Run NodeJS code via nodemon
 CMD ["npm", "run", "dev"]

--- a/core/Containerfile.stable
+++ b/core/Containerfile.stable
@@ -37,6 +37,9 @@ ENV NODE_ENV production
 ## Copy the various PM2 scripts into the PATH
 COPY --from=builder /morio/core/bin/* /usr/local/bin/
 
+## Copy the PM2 config file
+COPY --from=builder /morio/core/pm2.stable.config.js /morio/core/pm2.config.js
+
 # Copy dependencies that were kept out of the bundle
 COPY --from=builder /morio/core/node_modules/ssh2 ./node_modules/ssh2
 COPY --from=builder /morio/core/node_modules/asn1 ./node_modules/asn1
@@ -52,9 +55,4 @@ RUN npm install pm2 -g
 COPY --from=builder /morio/core/dist/index.mjs ./dist/index.mjs
 
 ## Now run NodeJS code inside PM2
-CMD [ "pm2-runtime", \
-  "--name", "core", \
-  "--namespace", "morio", \
-  "--log-type", "json", \
-  "--max-memory-bytes", "250000000", \
-  "./dist/index.mjs" ]
+CMD [ "pm2-runtime", "start", "/morio/core/pm2.config.js" ]

--- a/core/package.json
+++ b/core/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "node build.mjs",
     "clean": "rimraf dist",
-    "dev": "nodemon src/index.mjs -w src -w config -w shared -w openapi --quiet -- --no-warnings",
+    "dev": "NODE_ENV=development pm2-runtime start /morio/core/pm2.dev.config.js",
     "lint": "eslint --fix 'src/**' 'config/**' 'shared/**' 'tests/**' 'openapi/**'",
     "prettier": "npx prettier --ignore-unknown --write .",
     "test": "../scripts/testcheck.sh && docker exec -it morio-core node --no-warnings --test-concurrency=1 --test",

--- a/core/pm2.dev.config.js
+++ b/core/pm2.dev.config.js
@@ -2,8 +2,8 @@ module.exports = {
   apps: [
     {
       name: 'core',
-      script: './dist/index.mjs',
-      cwd: '/morio/api',
+      script: './src/index.mjs',
+      cwd: '/morio/core',
       max_memory_restart: '250M',
       watch: ['./src'],
     },

--- a/core/pm2.dev.config.js
+++ b/core/pm2.dev.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  apps: [
+    {
+      name: 'core',
+      script: './dist/index.mjs',
+      cwd: '/morio/api',
+      max_memory_restart: '250M',
+      watch: ['./src'],
+    },
+  ],
+}

--- a/core/pm2.stable.config.js
+++ b/core/pm2.stable.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  apps: [
+    {
+      name: 'core',
+      script: './dist/index.mjs',
+      cwd: '/morio/api',
+      max_memory_restart: '250M',
+      watch: false,
+    },
+  ],
+}

--- a/core/src/controllers/cluster.mjs
+++ b/core/src/controllers/cluster.mjs
@@ -191,15 +191,20 @@ Controller.prototype.join = async function (req, res) {
   if (!result) return utils.sendErrorResponse(res, 'morio.core.fs.write.failed', req.url)
   log.debug(`Writing node data to node.json`)
   const nodeUuid = uuid()
-  await writeJsonFile(`/etc/morio/node.json`, {
-    fqdn: valid.you,
-    hostname: valid.you.split('.')[0],
-    serial:
-      valid.settings.data.cluster.broker_nodes
-        .concat(valid.settings.data.cluster.flanking_nodes || [])
-        .indexOf(valid.you) + 1,
-    uuid: nodeUuid,
-  })
+  let nodeSerial = false
+  if (valid.settings.data.cluster.broker_nodes.includes(valid.you)) {
+    nodeSerial = valid.settings.data.cluster.broker_nodes.indexOf(valid.you) + 1
+  } else if ((valid.settings.data.cluster.flanking_nodes || []).includes(valid.you)) {
+    nodeSerial = valid.settings.data.cluster.flanking_nodes.indexOf(valid.you) + 100
+  }
+  if (!nodeSerial) log.warn(`Unable to determine node serial. This will not end well.`)
+  else
+    await writeJsonFile(`/etc/morio/node.json`, {
+      fqdn: valid.you,
+      hostname: valid.you.split('.')[0],
+      serial: nodeSerial,
+      uuid: nodeUuid,
+    })
 
   /*
    * We need to generate the CA config before we trigger a reload event

--- a/core/src/controllers/cluster.mjs
+++ b/core/src/controllers/cluster.mjs
@@ -195,7 +195,7 @@ Controller.prototype.join = async function (req, res) {
   if (valid.settings.data.cluster.broker_nodes.includes(valid.you)) {
     nodeSerial = valid.settings.data.cluster.broker_nodes.indexOf(valid.you) + 1
   } else if ((valid.settings.data.cluster.flanking_nodes || []).includes(valid.you)) {
-    nodeSerial = valid.settings.data.cluster.flanking_nodes.indexOf(valid.you) + 100
+    nodeSerial = valid.settings.data.cluster.flanking_nodes.indexOf(valid.you) + 101
   }
   if (!nodeSerial) log.warn(`Unable to determine node serial. This will not end well.`)
   else

--- a/core/src/lib/cluster.mjs
+++ b/core/src/lib/cluster.mjs
@@ -269,10 +269,13 @@ async function sendHeartbeat(fqdn, broadcast = false, justOnce = false) {
         },
         to: fqdn,
         cluster: utils.getClusterUuid(),
-        cluster_leader: {
-          serial: utils.getLeaderSerial() || undefined,
-          uuid: utils.getLeaderUuid() || undefined,
-        },
+        // Flanking nodes do not send/know the cluster leader
+        cluster_leader: utils.isFlankingNode()
+          ? undefined
+          : {
+              serial: utils.getLeaderSerial() || undefined,
+              uuid: utils.getLeaderUuid() || undefined,
+            },
         version: utils.getVersion(),
         settings_serial: Number(utils.getSettingsSerial()),
         keys_serial: Number(utils.getKeysSerial()),
@@ -508,8 +511,11 @@ export async function verifyHeartbeatRequest(data, type = 'heartbeat') {
   /*
    * Verify leader (only for heatbeats)
    * If there's a mismatch, ask to re-elect the cluster leader.
+   * However, flanking nodes do not know/care who the cluster leader is.
+   * So this only matters for broker nodes.
+   * Note that a healthcheck from a flanking node will not include data.cluster_leader.
    */
-  if (!data.cluster_leader?.serial || data.cluster_leader.serial !== utils.getLeaderSerial()) {
+  if (data.cluster_leader && data.cluster_leader.serial !== utils.getLeaderSerial()) {
     /*
      * Do they look to us as their leader?
      */

--- a/core/src/lib/cluster.mjs
+++ b/core/src/lib/cluster.mjs
@@ -136,7 +136,7 @@ async function ensureClusterHeartbeat() {
   }
 
   /*
-   * Let people know w're staring the heartbeat
+   * Let people know we're starting the heartbeat
    */
   log.debug(`Starting cluster heartbeat`)
   runHeartbeat(true, false)
@@ -155,7 +155,7 @@ export async function runHeartbeat(broadcast = false, justOnce = false) {
    *
    * Ensure we are comparing to up to date cluster state
    * Unless this is the initial setup in which case we just updated the state
-   * and should perhaps let the world knoww we just work up
+   * and should perhaps let the world know we just work up
    */
   if (!broadcast) await updateClusterState()
 
@@ -210,14 +210,14 @@ export async function runHeartbeat(broadcast = false, justOnce = false) {
 /**
  * Start a local heartbeat
  *
- * When Morio has only 1 node. Or when Morio has only 1 broker node,
+ * When Morio has only 1 node, or when Morio has only 1 broker node,
  * we will run a local heartbeat. This will not reach out over the network
  * but merely trigger the heartbeat lifecycle event locally, as that is what
  * used to keep things up to date.
  *
  * The reason we also run it when there is only 1 broker node is that
  * in a scenario where we have 1 broker node + 1 flanking node, the flanking
- * node going down would mean there is no long a heartbeat, and thus the cluster
+ * node going down would mean there is no longer a heartbeat, and thus the cluster
  * will start to decay.
  *
  */
@@ -313,7 +313,7 @@ async function sendHeartbeat(fqdn, broadcast = false, justOnce = false) {
   verifyHeartbeatResponse({ fqdn, data, rtt })
 
   /*
-   * Trigger a new heatbeat
+   * Trigger a new heartbeat
    */
   if (!justOnce) runHeartbeat(false, false)
 }
@@ -349,7 +349,7 @@ function verifyHeartbeatResponse({ fqdn, data, rtt = 0, error = false }) {
    */
   if (error || data?.code) {
     /*
-     * Storing the result of a failed hearbteat will influence the cluster state
+     * Storing the result of a failed heartbeat will influence the cluster state
      */
     utils.setHeartbeatIn(fqdn, { up: false, ok: false, error: error.code })
     /*
@@ -414,7 +414,7 @@ function verifyHeartbeatResponse({ fqdn, data, rtt = 0, error = false }) {
   } else if (Array.isArray(data?.nodes)) {
     for (const uuid in data.nodes) {
       /*
-       * It it's a valid hearbeat, add the node info to the state
+       * If it's a valid hearbeat, add the node info to the state
        */
       if (uuid !== utils.getNodeUuid()) utils.setClusterNode(uuid, data.nodes[uuid])
     }
@@ -469,7 +469,7 @@ export async function verifyHeartbeatRequest(data, type = 'heartbeat') {
   }
 
   /*
-   * Verify the 'to' is really us as a mismatch here can indicate fault DNS configuration
+   * Verify the 'to' is really us as a mismatch here can indicate faulty DNS configuration
    */
   if (utils.getNodeFqdn() !== data.to) {
     const err = 'HEARTBEAT_TARGET_FQDN_MISMATCH'
@@ -585,7 +585,7 @@ export async function verifyHeartbeatRequest(data, type = 'heartbeat') {
  *
  * This is called from the beforeall lifecycle hook
  * Note that Morio always runs in cluster mode
- * to ensure we can reach flanking nodes whne they are added.
+ * to ensure we can reach flanking nodes when they are added.
  */
 export async function ensureMorioCluster() {
   utils.setCoreReady(false)
@@ -627,7 +627,7 @@ export async function ensureMorioCluster() {
 }
 
 /*
- * Helpoer method to invite a single node to join the cluster
+ * Helper method to invite a single node to join the cluster
  *
  * @param {string} fqdn - The fqdn of the remote node
  */
@@ -667,7 +667,7 @@ async function inviteClusterNodeAttempt(remote) {
   const flanking = utils.isThisAFlankingNode({ fqdn: remote })
 
   /*
-   * Load data from disk becauise what we sync between cluster nodes
+   * Load data from disk because what we sync between cluster nodes
    * is what is written to disk.
    */
   const timestamp = utils.getSettingsSerial()

--- a/core/src/lib/cluster.mjs
+++ b/core/src/lib/cluster.mjs
@@ -125,9 +125,16 @@ export async function ensureMorioClusterConsensus() {
  */
 async function ensureClusterHeartbeat() {
   /*
-   * If we are leading the cluster, don't bother
+   * If we are leading the cluster, run a single heartbeat broadcast.
+   * As leader, we do not have to send heartbeats, but it is possible
+   * that the config was updated on this node, so we need to broadcast
+   * the reload event.
    */
-  if (utils.isLeading()) return false
+  if (utils.isLeading()) {
+    log.debug(`Sending broadcast cluster heartbeat`)
+    runHeartbeat(true, true)
+    return false
+  }
 
   /*
    * Let people know w're staring the heartbeat
@@ -690,6 +697,7 @@ async function inviteClusterNodeAttempt(remote) {
   /*
    * Validate response
    */
+  if (result.status && result.status !== 200) return false
   const [valid, err] = await validate(`res.cluster.join`, result)
   if (valid) log.info(`Node ${valid.node} will join the cluster`)
   else log.todo(err, `Handle cluster join failure.`)

--- a/core/src/lib/cluster.mjs
+++ b/core/src/lib/cluster.mjs
@@ -2,7 +2,7 @@
 import { testUrl } from '#shared/network'
 import { attempt } from '#shared/utils'
 import { serviceCodes } from '#shared/errors'
-import { serviceOrder, ephemeralServiceOrder, optionalServices } from '#config'
+import { serviceOrder, ephemeralServiceOrder } from '#config'
 // Core imports
 import { ensureMorioNetwork, runHook } from './services/index.mjs'
 import { isBrokerLeading } from './services/broker.mjs'
@@ -55,8 +55,7 @@ async function updateNodeState() {
    */
   const promises = []
   for (const service of utils.isEphemeral() ? ephemeralServiceOrder : serviceOrder) {
-    if (optionalServices.includes(service) || (await runHook('wanted', service)))
-      promises.push(runHook('heartbeat', service))
+    if (await runHook('wanted', service)) promises.push(runHook('heartbeat', service))
   }
   /*
    * Do the same for core as the final service

--- a/core/src/lib/services/api.mjs
+++ b/core/src/lib/services/api.mjs
@@ -4,7 +4,7 @@ import { testUrl } from '#shared/network'
 import { attempt } from '#shared/utils'
 import { ensureServiceCertificate } from '#lib/tls'
 // Default hooks
-import { defaultRecreateServiceHook, defaultRestartServiceHook } from './index.mjs'
+import { defaultRestartServiceHook, defaultRecreateServiceHook } from './index.mjs'
 
 /**
  * Service object holds the various lifecycle methods
@@ -23,8 +23,9 @@ export const service = {
     },
     /*
      * Lifecycle hook to determine whether the container is wanted
+     * The API service is _always_ wanted.
      */
-    wanted: ensureLocalPrerequisites,
+    wanted: () => true,
     /**
      * Lifecycle hook for anything to be done prior to creating the container
      */

--- a/core/src/lib/services/api.mjs
+++ b/core/src/lib/services/api.mjs
@@ -89,11 +89,11 @@ async function ensureLocalPrerequisites() {
   /*
    * Write PM2 config file
    */
-  const pm2 = utils.getMorioServiceConfig('api')
-  if (pm2)
+  const config = utils.getMorioServiceConfig('api')
+  if (config?.pm2)
     await writeFile(
       `/etc/morio/api/pm2.config.js`,
-      `module.exports=${JSON.stringify(utils.getMorioServiceConfig('api').pm2, null, 2)}`
+      `module.exports=${JSON.stringify(config.pm2, null, 2)}`
     )
 
   return

--- a/core/src/lib/services/api.mjs
+++ b/core/src/lib/services/api.mjs
@@ -1,5 +1,5 @@
 import { utils, log } from '../utils.mjs'
-import { chown, mkdir } from '#shared/fs'
+import { chown, mkdir, writeFile } from '#shared/fs'
 import { testUrl } from '#shared/network'
 import { attempt } from '#shared/utils'
 import { ensureServiceCertificate } from '#lib/tls'
@@ -84,6 +84,16 @@ async function ensureLocalPrerequisites() {
    * (this will only renew the cert if it's missing or old)
    */
   await ensureServiceCertificate('api', false)
+
+  /*
+   * Write PM2 config file
+   */
+  const pm2 = utils.getMorioServiceConfig('api')
+  if (pm2)
+    await writeFile(
+      `/etc/morio/api/pm2.config.js`,
+      `module.exports=${JSON.stringify(utils.getMorioServiceConfig('api').pm2, null, 2)}`
+    )
 
   return
 }

--- a/core/src/lib/services/broker.mjs
+++ b/core/src/lib/services/broker.mjs
@@ -69,7 +69,7 @@ export const service = {
     },
     /*
      * Lifecycle hook to determine whether the container is wanted
-     * The broker service is wantes on broker nodes in non-ephemeral state
+     * The broker service is wanted on broker nodes in non-ephemeral state
      */
     wanted: () => {
       if (utils.isEphemeral()) return false

--- a/core/src/lib/services/broker.mjs
+++ b/core/src/lib/services/broker.mjs
@@ -13,11 +13,7 @@ import { ensureServiceCertificate } from '#lib/tls'
 import { execContainerCommand } from '#lib/docker'
 import { testUrl, restClient } from '#shared/network'
 // Default hooks
-import {
-  defaultServiceWantedHook,
-  defaultRecreateServiceHook,
-  defaultRestartServiceHook,
-} from './index.mjs'
+import { defaultRecreateServiceHook, defaultRestartServiceHook } from './index.mjs'
 // log & utils
 import { log, utils } from '../utils.mjs'
 
@@ -73,9 +69,13 @@ export const service = {
     },
     /*
      * Lifecycle hook to determine whether the container is wanted
-     * We just reuse the default hook here, checking for ephemeral state
+     * The broker service is wantes on broker nodes in non-ephemeral state
      */
-    wanted: defaultServiceWantedHook,
+    wanted: () => {
+      if (utils.isEphemeral()) return false
+      if (utils.isFlankingNode()) return false
+      return true
+    },
     /*
      * Lifecycle hook to determine whether to recreate the container
      * We just reuse the default hook here, checking for changes in

--- a/core/src/lib/services/ca.mjs
+++ b/core/src/lib/services/ca.mjs
@@ -33,12 +33,12 @@ export const service = {
     },
     /*
      * Lifecycle hook to determine whether the container is wanted
-     * TODO:
-     * For a true highly-available CA, we need to hook it up to our
-     * distributed database. See: https://github.com/smallstep/nosql/issues/64
-     * Until then, we can get by with a single CA.
+     * CA runs on all broker nodes.
      */
-    wanted: () => true,
+    wanted: () => {
+      if (utils.isEphemeral()) return false
+      return utils.isBrokerNode() ? true : false
+    },
     /*
      * Lifecycle hook to determine whether to recreate the container
      * We just reuse the default hook here, checking for changes in

--- a/core/src/lib/services/cache.mjs
+++ b/core/src/lib/services/cache.mjs
@@ -17,7 +17,28 @@ export const service = {
      *
      * @return {boolean} wanted - Wanted or not
      */
-    wanted: () => utils.getFlag('ENFORCE_SERVICE_CACHE') || isTapWanted(),
+    wanted: () => {
+      if (utils.isEphemeral()) return false
+      if (utils.getFlag('ENFORCE_SERVICE_CACHE') || isTapWanted()) {
+        /*
+         * We need a cache service, but where do we run it?
+         * Do we have a specific cache node in the settings?
+         */
+        const cacheNode = utils.getSettings('flanking_services.cache.nodes', []).pop()
+        if (cacheNode) return cacheNode === utils.getNodeFqdn() ? true : false
+        /*
+         * No explicit cache node configured.
+         * We will run it on the node with the lowest serial.
+         * First we check flanking nodes, finally we try broker nodes.
+         */
+        if (utils.getFlankingCount() > 0)
+          return utils.getNodeSerial() === utils.getLowestFlankingNodeSerial() ? true : false
+        else return utils.getNodeSerial() === utils.getLowestBrokerNodeSerial() ? true : false
+      }
+
+      // By default, we do not run the cache service
+      return false
+    },
     /*
      * Lifecycle hook to determine whether to recreate the container
      * We just reuse the default hook here, checking for changes in

--- a/core/src/lib/services/connector.mjs
+++ b/core/src/lib/services/connector.mjs
@@ -13,21 +13,46 @@ export const service = {
   hooks: {
     /**
      * Lifecycle hook to determine whether the container is wanted
-     *
-     * For the connector, the answer is only true when there are pipelines configured
-     *
-     * @return {boolean} wanted - Wanted or not
      */
     wanted: async () => {
       const sinks = utils.getSettings('connector.sinks', false)
-
       // Without sinks, this service should not be started
       if (sinks === false || Object.values(sinks).filter((sink) => !sink.disabled).length < 1)
         return false
-      // Always update pipeline config until we have a way to diff them
-      else await ensurePipelines()
 
-      return true
+      /*
+       * We need a connector service, but where do we run it?
+       * Do we have a specific connector node in the settings?
+       */
+      const cNodes = utils.getSettings('flanking_services.connector.nodes', [])
+      if (cNodes.includes(utils.getNodeFqdn())) {
+        // Always update pipeline config until we have a way to diff them
+        await ensurePipelines()
+        return true
+      }
+      /*
+       * If there are explicit nodes, we are not part of them.
+       * So do not run this service.
+       */
+      if (cNodes.length > 0) return false
+      /*
+       * No explicit connector node configured.
+       * We will run it on all flanking nodes, or all broker nodes.
+       */
+      if (utils.getFlankingCount() > 0) {
+        if (utils.isFlankingNode()) {
+          // Always update pipeline config until we have a way to diff them
+          await ensurePipelines()
+          return true
+        }
+      } else {
+        // Always update pipeline config until we have a way to diff them
+        await ensurePipelines()
+
+        return true
+      }
+
+      return false
     },
     /*
      * Lifecycle hook to determine whether to recreate the container

--- a/core/src/lib/services/connector.mjs
+++ b/core/src/lib/services/connector.mjs
@@ -48,7 +48,6 @@ export const service = {
       } else {
         // Always update pipeline config until we have a way to diff them
         await ensurePipelines()
-
         return true
       }
 

--- a/core/src/lib/services/console.mjs
+++ b/core/src/lib/services/console.mjs
@@ -1,11 +1,7 @@
 import { ensureServiceCertificate } from '#lib/tls'
 import { writeYamlFile } from '#shared/fs'
 // Default hooks
-import {
-  defaultServiceWantedHook,
-  defaultRecreateServiceHook,
-  defaultRestartServiceHook,
-} from './index.mjs'
+import { defaultRecreateServiceHook, defaultRestartServiceHook } from './index.mjs'
 import { testUrl } from '#shared/network'
 // log & utils
 import { utils } from '../utils.mjs'
@@ -31,9 +27,13 @@ export const service = {
     },
     /*
      * Lifecycle hook to determine whether the container is wanted
-     * We just reuse the default hook here, checking for ephemeral state
+     * The console service is wanted on broker nodes in non-ephemeral state
      */
-    wanted: defaultServiceWantedHook,
+    wanted: () => {
+      if (utils.isEphemeral()) return false
+      if (utils.isFlankingNode()) return false
+      return true
+    },
     /*
      * Lifecycle hook to determine whether to recreate the container
      * We just reuse the default hook here, checking for changes in

--- a/core/src/lib/services/core.mjs
+++ b/core/src/lib/services/core.mjs
@@ -7,7 +7,7 @@ import { encryptionMethods, hash } from '#shared/crypto'
 // Used for templating the settings
 import mustache from 'mustache'
 // Default hooks & netork handler
-import { alwaysTrue, ensureMorioService } from './index.mjs'
+import { ensureMorioService } from './index.mjs'
 // Cluster code
 import { ensureMorioCluster } from '#lib/cluster'
 // log & utils
@@ -50,9 +50,9 @@ export const service = {
     },
     /*
      * Lifecycle hook to determine whether the container is wanted
-     * We reuse the alwaysTrue method here, since core should always be running
+     * The core service is _always_ wanted.
      */
-    wanted: alwaysTrue,
+    wanted: () => true,
     /*
      * This runs only when core is cold-started.
      *

--- a/core/src/lib/services/db.mjs
+++ b/core/src/lib/services/db.mjs
@@ -2,11 +2,7 @@ import { mkdir } from '#shared/fs'
 import { restClient, testUrl } from '#shared/network'
 import { attempt } from '#shared/utils'
 import { ensureServiceCertificate } from '#lib/tls'
-import {
-  defaultServiceWantedHook,
-  defaultRecreateServiceHook,
-  defaultRestartServiceHook,
-} from './index.mjs'
+import { defaultRecreateServiceHook, defaultRestartServiceHook } from './index.mjs'
 import { log, utils } from '../utils.mjs'
 
 const dbClient = restClient(`http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}db:4001`)
@@ -35,9 +31,13 @@ export const service = {
     },
     /*
      * Lifecycle hook to determine whether the container is wanted
-     * We just reuse the default hook here, checking for ephemeral state
+     * The DB service runs on all broker nodes
      */
-    wanted: defaultServiceWantedHook,
+    wanted: () => {
+      if (utils.isEphemeral()) return false
+      if (utils.isFlankingNode()) return false
+      return true
+    },
     /**
      * Lifecycle hook for anything to be done prior to creating the container
      *

--- a/core/src/lib/services/index.mjs
+++ b/core/src/lib/services/index.mjs
@@ -185,7 +185,7 @@ export async function ensureMorioService(serviceName, hookParams = {}) {
   )
 
   /*
-   * If the service optional, not wanted, yet running, stop it
+   * If the service is not wanted, yet running, stop it
    */
   const wanted = await runHook('wanted', serviceName, hookParams)
   if (!wanted) {

--- a/core/src/lib/services/index.mjs
+++ b/core/src/lib/services/index.mjs
@@ -288,7 +288,7 @@ async function shouldServiceBeRecreated(serviceName, hookParams) {
    */
   const running = isContainerRunning(serviceName)
   if (!running) {
-    log.debug({ running }, `[${serviceName}] Service is not running. Recreating service`)
+    log.debug(`[${serviceName}] Service is not running. Recreating service`)
     return true
   }
 

--- a/core/src/lib/services/index.mjs
+++ b/core/src/lib/services/index.mjs
@@ -385,34 +385,6 @@ export async function restartMorioService(serviceName, id) {
 }
 
 /**
- * The default wanted lifecycle hook
- *
- * Containers need to specify this hook, but for several containers
- * we just check whether we are running in ephemeral state of not.
- * So rather than create that hook for each service, we reuse this method.
- *
- * @retrun {boolean} result - True to indicate the container is wanted
- */
-export function defaultServiceWantedHook() {
-  return utils.isEphemeral() ? false : true
-}
-
-/**
- * The 'always true' method
- *
- * Containers need to specify various lifecycle hooks.
- * But some containers should always be running, or always be
- * restarted and so on.
- * So rather than create that hook for each service, we reuse this
- * method.
- *
- * @retrun {boolean} result - always true
- */
-export function alwaysTrue() {
-  return true
-}
-
-/**
  * The default recreateService lifecycle hook
  *
  * Containers need to specify this hook, but for most containers

--- a/core/src/lib/services/index.mjs
+++ b/core/src/lib/services/index.mjs
@@ -12,12 +12,7 @@ import { service as proxyService, ensureTraefikDynamicConfiguration } from './pr
 import { service as tapService } from './tap.mjs'
 import { service as watcherService } from './watcher.mjs'
 // Dependencies
-import {
-  resolveServiceConfiguration,
-  serviceOrder,
-  ephemeralServiceOrder,
-  optionalServices,
-} from '#config'
+import { resolveServiceConfiguration, serviceOrder, ephemeralServiceOrder, hookMsg } from '#config'
 // Docker
 import {
   docker,
@@ -181,7 +176,7 @@ export async function startMorio(hookParams = {}) {
  */
 export async function ensureMorioService(serviceName, hookParams = {}) {
   /*
-   * Start by generating the  morio service config so it's available in all hooks
+   * Start by generating the morio service config so it's available in all hooks
    * Docker config will be generated after the preCreate lifecycle hook
    */
   utils.setMorioServiceConfig(
@@ -189,30 +184,27 @@ export async function ensureMorioService(serviceName, hookParams = {}) {
     resolveServiceConfiguration(serviceName, { utils, hookParams })
   )
 
-  if (optionalServices.includes(serviceName)) {
+  /*
+   * If the service optional, not wanted, yet running, stop it
+   */
+  const wanted = await runHook('wanted', serviceName, hookParams)
+  if (!wanted) {
+    const running = isContainerRunning(serviceName)
     /*
-     * If the service optional, not wanted, yet running, stop it
+     * Stopping services can take a long time.
+     * No need to wait for that, we can continue with other services.
+     * So we're letting this run its course async, rather than waiting for it.
      */
-    const wanted = await runHook('wanted', serviceName, hookParams)
-    if (!wanted) {
-      log.debug(`[${serviceName}] Optional service is not wanted`)
-      const running = isContainerRunning(serviceName)
-      /*
-       * Stopping services can take a long time.
-       * No need to wait for that, we can continue with other services.
-       * So we're letting this run its course async, rather than waiting for it.
-       */
-      log.debug(`[${serviceName}] Optional service is running, but not wanted. Shutting down...`)
-      if (running)
-        stopMorioService(serviceName).then((result) => {
-          if (result[0] === true)
-            log.debug(`[${serviceName}] Stopped service as it is no longer wanted`)
-          else log.warn(`[${serviceName}] Unexpected result when attempting to stop the service`)
-        })
+    log.debug(`[${serviceName}] Service is running, but not wanted. Shutting down...`)
+    if (running)
+      stopMorioService(serviceName).then((result) => {
+        if (result[0] === true)
+          log.debug(`[${serviceName}] Stopped service as it is no longer wanted`)
+        else log.warn(`[${serviceName}] Unexpected result when attempting to stop the service`)
+      })
 
-      // Not wanted, return early
-      return true
-    } else log.debug(`[${serviceName}] Optional service is wanted`)
+    // Not wanted, return early
+    return true
   }
 
   /*
@@ -226,8 +218,6 @@ export async function ensureMorioService(serviceName, hookParams = {}) {
      * Run precreate lifecycle hook
      */
     await runHook('precreate', serviceName, hookParams)
-  } else {
-    log.debug(`[${serviceName}] Not updating container`)
   }
 
   /*
@@ -260,8 +250,6 @@ export async function ensureMorioService(serviceName, hookParams = {}) {
      * Run postStart lifecycle hook
      */
     await runHook('poststart', serviceName, { ...hookParams, recreate })
-  } else {
-    log.debug(`[${serviceName}] Not restarting service`)
   }
 
   /*
@@ -345,8 +333,10 @@ export async function runHook(hookName, serviceName, hookParams) {
     log.warn(err, `[${serviceName}] Error in the ${hookName} hook`)
   }
 
-  if (!result && !['wanted', 'recreate', 'restart', 'heartbeat'].includes(hookName)) {
-    log.warn(`[${serviceName}] The ${hookName} hook failed`)
+  if (!result) {
+    if (['wanted', 'recreate', 'restart'].includes(hookName))
+      log.debug(`[${serviceName}] ${hookMsg.ko[hookName]}`)
+    else log.warn(`[${serviceName}] The ${hookName} hook failed`)
   }
 
   return result

--- a/core/src/lib/services/proxy.mjs
+++ b/core/src/lib/services/proxy.mjs
@@ -1,7 +1,7 @@
 import { readFile, writeFile, writeYamlFile, mkdir } from '#shared/fs'
 import { testUrl } from '#shared/network'
 // Default hooks
-import { defaultRecreateServiceHook, alwaysTrue, defaultRestartServiceHook } from './index.mjs'
+import { defaultRecreateServiceHook, defaultRestartServiceHook } from './index.mjs'
 // log & utils
 import { log, utils } from '../utils.mjs'
 
@@ -29,9 +29,9 @@ export const service = {
     },
     /*
      * Lifecycle hook to determine whether the container is wanted
-     * We reuse the alwaysTrue method here, since the proxy service should always be running
+     * The proxy service is _always_ wanted.
      */
-    wanted: alwaysTrue,
+    wanted: () => true,
     /*
      * Lifecycle hook to determine whether to recreate the container.
      * FIXME: Do we need to always recreate this?

--- a/core/src/lib/services/tap.mjs
+++ b/core/src/lib/services/tap.mjs
@@ -18,13 +18,35 @@ export const service = {
      * @return {boolean} wanted - Wanted or not
      */
     wanted: () => {
-      /*
-       * Only run the tap service if any stream processors are loaded & enabled
-       * FIXME: Handle dynamic loading of processors
-       */
+      if (utils.isEphemeral()) return false
       if (isTapWanted()) {
-        ensureLocalPrerequisites()
-        return true
+        /*
+         * We need a tap service, but where do we run it?
+         * Do we have a specific tap node in the settings?
+         */
+        const tNodes = utils.getSettings('flanking_services.connector.tap', [])
+        if (tNodes.includes(utils.getNodeFqdn())) {
+          ensureLocalPrerequisites()
+          return true
+        }
+        /*
+         * If there are explicit nodes, we are not part of them.
+         * So do not run this service.
+         */
+        if (tNodes.length > 0) return false
+        /*
+         * No explicit tap node configured.
+         * We will run it on all flanking nodes, or all broker nodes.
+         */
+        if (utils.getFlankingCount() > 0) {
+          if (utils.isFlankingNode()) {
+            ensureLocalPrerequisites()
+            return true
+          }
+        } else {
+          ensureLocalPrerequisites()
+          return true
+        }
       }
 
       return false

--- a/core/src/lib/services/watcher.mjs
+++ b/core/src/lib/services/watcher.mjs
@@ -1,11 +1,7 @@
 import { writeYamlFile, chown, mkdir, cp } from '#shared/fs'
 import { ensureServiceCertificate } from '#lib/tls'
 // Default hooks
-import {
-  defaultRecreateServiceHook,
-  defaultRestartServiceHook,
-  defaultServiceWantedHook,
-} from './index.mjs'
+import { defaultRecreateServiceHook, defaultRestartServiceHook } from './index.mjs'
 // log & utils
 import { log, utils } from '../utils.mjs'
 
@@ -17,14 +13,24 @@ export const service = {
   hooks: {
     /**
      * Lifecycle hook to determine whether the container is wanted
-     *
-     * For the watcher, the answer is only true when there are monitors configured
-     * However, Morio configures its own internal monitors, so there are _always_
-     * monitors, so we just defer to the default hook
-     *
-     * @return {boolean} wanted - Wanted or not
      */
-    wanted: defaultServiceWantedHook,
+    wanted: async () => {
+      const wNodes = utils.getSettings('flanking_services.watcher.nodes', [])
+      if (wNodes.includes(utils.getNodeFqdn())) return true
+      /*
+       * If there are explicit nodes, we are not part of them.
+       * So do not run this service.
+       */
+      if (wNodes.length > 0) return false
+      /*
+       * No explicit watcher node configured.
+       * We will run it on the node with the lowest serial.
+       * First we check flanking nodes, finally we try broker nodes.
+       */
+      if (utils.getFlankingCount() > 0)
+        return utils.getNodeSerial() === utils.getLowestFlankingNodeSerial() ? true : false
+      else return utils.getNodeSerial() === utils.getLowestBrokerNodeSerial() ? true : false
+    },
     /*
      * Lifecycle hook to determine whether to recreate the container
      * We just reuse the default hook here, checking for changes in

--- a/core/src/lib/utils.mjs
+++ b/core/src/lib/utils.mjs
@@ -930,9 +930,9 @@ utils.setVersion = (version) => {
  */
 
 /**
- * Helper method to see whether the config is resolved
+ * Helper method to see whether a node is a broker node
  *
- * @return {bool} resolved - True if the config is resolved, false if not
+ * @return {bool} brokerNode - True if the local node is a broker node, false if not
  */
 utils.isBrokerNode = () => (utils.getNodeSerial() < 100 ? true : false)
 
@@ -967,6 +967,13 @@ utils.isDistributed = () =>
  * @return {bool} ephemeral - True if ephemeral, false if not
  */
 utils.isEphemeral = () => (store.get('state.ephemeral', false) ? true : false)
+
+/**
+ * Helper method to see whether a node is a flanking node
+ *
+ * @return {bool} brokerNode - True if the local node is a flanking node, false if not
+ */
+utils.isFlankingNode = () => (utils.getNodeSerial() > 100 ? true : false)
 
 /*
  * Determine whether this node is leading the cluster
@@ -1119,7 +1126,11 @@ utils.endReload = () => {
   store.set('state.reload_count', Number(store.get('state.reload_count')) + 1)
   const serial = store.get('state.settings_serial')
   log.info(
-    `Configuration Resolved - ${serial ? 'Running settings serial ' + serial : 'Running in ephemeral mode'}`
+    `Configuration Resolved - ${
+      serial
+        ? 'Running settings serial ' + serial + ', node serial ' + utils.getNodeSerial()
+        : 'Running in ephemeral mode'
+    }`
   )
   return utils
 }

--- a/shared/src/network.mjs
+++ b/shared/src/network.mjs
@@ -25,7 +25,7 @@ export async function resolveHost(host) {
     return [false, `Failed to resolve host: ${host}`]
   }
 
-  return [true, result.map((record) => record.address)]
+  return [true, [...new Set(result.map((record) => record.address))]]
 }
 
 /**

--- a/shared/src/schema.mjs
+++ b/shared/src/schema.mjs
@@ -231,6 +231,12 @@ const settings = Joi.object({
     comment: Joi.alternatives().try(Joi.string(), Joi.array().items(Joi.string())),
     version: Joi.alternatives().try(Joi.string(), Joi.number()),
   }),
+  flanking_services: Joi.object({
+    cache: Joi.object({ nodes: flankingNodes }).optional(),
+    connector: Joi.object({ nodes: flankingNodes }).optional(),
+    tap: Joi.object({ nodes: flankingNodes }).optional(),
+    watcher: Joi.object({ nodes: flankingNodes }).optional(),
+  }),
   connector: Joi.object(),
   tokens: Joi.object({
     flags: Joi.object({

--- a/ui/components/settings/blocks/index.mjs
+++ b/ui/components/settings/blocks/index.mjs
@@ -24,7 +24,7 @@ const blocks = {
 const LockedOnEdit = () => (
   <Popout note>
     <h5>These settings are locked</h5>
-    <p>Once deployed, these settings cannot be changed.</p>
+    <p>Once deployed, these settings cannot be changed through the UI.</p>
   </Popout>
 )
 
@@ -50,8 +50,10 @@ export const Block = (props) => {
       </Popout>
     ) : (
       <>
-        {props.edit && props.template.lockOnEdit ? <LockedOnEdit /> : null}
-        <Component {...props} {...viewConfig} viewConfig={viewConfig} disabled={disabled} />
+        {props.edit && props.template.lockOnEdit
+          ? <LockedOnEdit />
+          : <Component {...props} {...viewConfig} viewConfig={viewConfig} disabled={disabled} />
+        }
       </>
     )
   } else {

--- a/ui/components/settings/navigation.mjs
+++ b/ui/components/settings/navigation.mjs
@@ -55,7 +55,7 @@ export const NavButton = ({
   /*
    * Pre-calculate some things we need
    */
-  const className = `w-full flex flex-row items-center px-4 py-2 rounded-l-lg ${extraClasses} ${
+  const className = `w-full flex flex-row items-center px-4 py-2 rounded-l-lg text-left ${extraClasses} ${
     active
       ? here
         ? 'bg-secondary bg-opacity-20 font-bold text-inherit border-secondary border border-r-0'

--- a/ui/components/settings/templates/flanking.mjs
+++ b/ui/components/settings/templates/flanking.mjs
@@ -80,19 +80,6 @@ const flankingServices = {
     ]
   }
 }
-/*
-cluster:
-  broker_nodes:
-    - bnode1
-    - bnode2
-    - bnode3
-  flanking_nodes:
-    - fnode1
-    - fnode2
-flanking_services:
-  cache:
-    nodes: []
-*/
 
 const updateServiceLocation = ({ service, val, node, context }) => {
   // Cache service is special because it can only run in 1 place
@@ -160,7 +147,7 @@ const FlankingNodeForm = ({ node, context }) => {
  * This holds the configuration wizard view settings
  * for any flanking nodes in the Morio deployment.
  */
-export const flanking = (context, toggleValidate) => {
+export const flanking = (context) => {
   const flankingNodes = []
   for (const node of context.mSettings?.cluster?.flanking_nodes || []) {
     flankingNodes.push(<FlankingNodeForm node={node} context={context} />)
@@ -182,7 +169,7 @@ export const flanking = (context, toggleValidate) => {
         form: [
           '### Flanking nodes',
           ...flankingNodes,
-          <p className="text-center">
+          <p className="text-center" key='p'>
             <button
               onClick={() => context.pushModal((
                 <ModalWrapper keepOpenOnClick wClass="max-w-2xl w-full">

--- a/ui/components/settings/templates/flanking.mjs
+++ b/ui/components/settings/templates/flanking.mjs
@@ -1,0 +1,203 @@
+import Joi from 'joi'
+import { arrayMembers, capitalize } from 'lib/utils.mjs'
+import { useState } from 'react'
+import { Popout } from 'components/popout.mjs'
+import { BoolNoIcon, BoolYesIcon, TipIcon } from 'components/icons.mjs'
+import { ModalWrapper } from 'components/layout/modal-wrapper.mjs'
+import { StringInput, ListInput } from 'components/inputs.mjs'
+
+const AddFlankingNode = ({ context }) => {
+  const [fqdn, setFqdn] = useState('')
+  const schema = Joi.string().hostname().required().label('FQDN')
+
+  const { update, clearModal, mSettings } = context
+
+  const add = () => {
+    // Update settings
+    update(
+      'cluster.flanking_nodes',
+      arrayMembers(mSettings.cluster.flanking_nodes || [], 'add', fqdn)
+    )
+    // Close modal
+    clearModal()
+  }
+
+  return (
+    <>
+      <h5>Flanking node FQDN</h5>
+      <small>Please enter the FQDN of the flanking node you want to add to this cluster</small>
+      <div className="flex flex-row gap-2 items-start">
+        <StringInput
+          label="FQDN"
+          update={setFqdn}
+          current={fqdn}
+          valid={() => schema.validate(fqdn)}
+        />
+        {/* We are adding an empty label to ensure button and input align vertically */}
+        <formcontrol>
+          <div className="label">
+            <span className="label-text">&nbsp;</span>
+          </div>
+          <button
+            className="btn btn-primary"
+            disabled={(schema.validate(fqdn)?.error) ? true : false}
+            onClick={add}
+          >Add</button>
+        </formcontrol>
+      </div>
+    </>
+  )
+}
+
+const flankingServices = {
+  cache: {
+    desc: 'A ValKey instance for storing dashboard data',
+    tips: [
+      'Run this on a flanking node if possible.',
+      'Only one instance of this service can be deployed per cluster.',
+      'Enabling this service here will disable it elsewhere.',
+    ],
+  },
+  connector: {
+    desc: 'A Vector instance for interconnecting Morio',
+    tips: [
+      'Run this on one or more flanking nodes if possible.',
+      'This service scales horizontally.',
+    ],
+  },
+  tap: {
+    desc: `Morio's low-code stream processing service`,
+    tips: [
+      'Run this on one or more flanking nodes if possible.',
+      'This service scales horizontally.',
+    ],
+  },
+  watcher: {
+    desc: `A heartbeat instance to run healthchecks`,
+    tips: [
+      'Run this on a flanking nodes if possible.',
+      'Multiple instances only add value if you want to run healthchecks from different origins (eg: different data centres).',
+    ]
+  }
+}
+/*
+cluster:
+  broker_nodes:
+    - bnode1
+    - bnode2
+    - bnode3
+  flanking_nodes:
+    - fnode1
+    - fnode2
+flanking_services:
+  cache:
+    nodes: []
+*/
+
+const updateServiceLocation = ({ service, val, node, context }) => {
+  // Cache service is special because it can only run in 1 place
+  if (service === 'cache') context.update(`flanking_services.${service}.nodes`, val ? [node] : [])
+  else context.update(
+    `flanking_services.${service}.nodes`,
+    arrayMembers((context.mSettings.flanking_services?.[service]?.nodes || []), (val ? 'add' : 'del'), node)
+  )
+}
+
+const FlankingNodeForm = ({ node, context }) => {
+
+  return (
+    <div className="">
+      <details className="bg-primary/20 rounded mt-4 open:bg-transparent open:border-l-4 open:shadow hover:bg-primary/30 open:hover:bg-transparent open:cusor-default border-primary group">
+        <summary className="flex flex-row gap-2 items-center justify-between hover:cursor-pointer px-2 group-open:bg-primary/20">
+          <h6><span className="text-xs opacity-70">Flanking Node:</span> {node}</h6>
+        </summary>
+        <div className="p-2">
+          <h5>Flanking Services</h5>
+          <p>You can choose which (flanking) services you want to run on this node.</p>
+          {Object.entries(flankingServices).map(([service, info]) => {
+            const enabled = (context.mSettings.flanking_services?.[service]?.nodes || []).includes(node) ? true : false
+
+            return (
+              <>
+                <h6>{capitalize(service)} Service</h6>
+                <div className="grid grid-cols-2 gap-2">
+                  <div className="mb-4">
+                    <span className="font-bold">{info.desc}</span>
+                    <ul className="list list-inside ml-2 list-disc text-sm">
+                      {info.tips.map(tip => (
+                        <li key={tip} className="flex flex-row items-start gap-2">
+                          <TipIcon className="w-4 h-4 text-success"/> {tip}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div className="">
+                    <ListInput
+                      update={(val) => updateServiceLocation({ service, val, node, context })}
+                      list={[
+                        { val: true, label: 'Run on this node' },
+                        { val: false, label: 'Disabled' },
+                      ]}
+                      current={enabled}
+                      dir='row'
+                      dense={true}
+                      activeIcon={enabled ? <BoolYesIcon /> : <BoolNoIcon />}
+                    />
+                  </div>
+                </div>
+              </>
+            )
+          })}
+        </div>
+      </details>
+    </div>
+  )
+}
+
+/*
+ * Flanking Nodes
+ *
+ * This holds the configuration wizard view settings
+ * for any flanking nodes in the Morio deployment.
+ */
+export const flanking = (context, toggleValidate) => {
+  const flankingNodes = []
+  for (const node of context.mSettings?.cluster?.flanking_nodes || []) {
+    flankingNodes.push(<FlankingNodeForm node={node} context={context} />)
+  }
+  if (flankingNodes.length === 0) flankingNodes.push(
+    <Popout note>
+      <h5>This cluster currently has no flanking nodes</h5>
+      To add a flanking node, click the <b>Add a flanking node</b> button below.
+    </Popout>
+  )
+
+  const template = {
+    title: 'Flanking Services',
+    type: 'info',
+    children: {
+      nodes: {
+        type: 'form',
+        title: 'Flanking Nodes',
+        form: [
+          '### Flanking nodes',
+          ...flankingNodes,
+          <p className="text-center">
+            <button
+              onClick={() => context.pushModal((
+                <ModalWrapper keepOpenOnClick wClass="max-w-2xl w-full">
+                  <AddFlankingNode context={context} />
+                </ModalWrapper>
+              ))}
+              className="btn btn-primary"
+            >
+              Add a flanking node
+            </button>
+          </p>,
+        ],
+      },
+    },
+  }
+
+  return template
+}

--- a/ui/components/settings/templates/flanking.mjs
+++ b/ui/components/settings/templates/flanking.mjs
@@ -75,7 +75,7 @@ const flankingServices = {
   watcher: {
     desc: `A heartbeat instance to run healthchecks`,
     tips: [
-      'Run this on a flanking nodes if possible.',
+      'Run this on a flanking node if possible.',
       'Multiple instances only add value if you want to run healthchecks from different origins (eg: different data centres).',
     ]
   }

--- a/ui/components/settings/templates/index.mjs
+++ b/ui/components/settings/templates/index.mjs
@@ -1,12 +1,17 @@
 import { iam } from './iam/index.mjs'
 import { connector } from './connector/index.mjs'
 import { cluster } from './cluster.mjs'
+import { flanking } from './flanking.mjs'
 import { tap } from './tap.mjs'
 import { tokens } from './tokens.mjs'
 //import { watcher } from './watcher.mjs'
 
+/*
+ * Note that this also controls the order in which they appear
+ */
 export const templates = {
   cluster,
+  flanking,
   iam,
   connector,
   //watcher,

--- a/ui/lib/utils.mjs
+++ b/ui/lib/utils.mjs
@@ -7,6 +7,14 @@ import _slugify from 'slugify'
 import { jwtDecode } from 'jwt-decode'
 import { roles } from 'config/roles.mjs'
 
+export const arrayMembers = (set, op='add', data) => {
+  const s = new Set(set)
+  if (op === 'add') s.add(data)
+  else s.delete(data)
+
+  return [...s]
+}
+
 export const asJson = (data, pretty = true) => {
   const json = {}
   for (const [key, val] of Object.entries(data)) {


### PR DESCRIPTION
This is a first batch of changes to improve the way flanking services are handled.
This focuses on the settings that allow users to change where flanking services should run (changes in UI and the settings schema), as well as the changes required in core to ensure orchestration enforces the desired state of the various services.

This lacks implementation of cross-cluster access to flanking services. For example:
- The API assumes that a DB service is available locally, but that is not the case on a flanking node
- The Tap service assumes that the Cache service is available locally, but that is not the case on a flanking node

A future update will address this by ensuring cross-cluster access to these services secured with mTLS, but I wanted to keep this pull request from getting too large.

**Added**

- [ui] Add UI to manage flanking nodes and services
- [core] Add selective deployment of flanking services

**Changed**

- Allow users to define where to run flanking services
- [api] Run in PM2 and restart when memory exceeds 250MB
- [core] Run in PM2 and restart when memory exceeds 250MB
- [core] Cluster join/heartbeat changes for flanking nodes

**Fixed**

- [api] Fix an issue in IP resolver validation
- [api] Fix an issue in flanking node validation

