### PR TITLE
[core] chore: Add .internal network alias to containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [console] Upgraded Redpanda Console from qlite from v2.8.3 to v2.8.5
 - [core] Run in PM2 and restart when memory exceeds 250MB
 - [core] Cluster join/heartbeat changes for flanking nodes
+- [core] Add .internal network aliases to facilitate proxy configuration
 - [db] Upgraded Rqlite from 8.36.12 to 8.36.16
 - [docs] Upgraded Docusaurus from 3.7.0 to 3.8.0
 - [proxy] Upgraded Traefik from v3.3.4 to v3.3.5

--- a/api/src/lib/utils.mjs
+++ b/api/src/lib/utils.mjs
@@ -614,7 +614,7 @@ utils.clearOidcPkce = (id, state) => store.unset(['oidc', 'pkce', id, state])
  * Returns a pre-configured API client, itself on object
  */
 utils.coreClient = restClient(
-  `http://${getPreset('MORIO_CONTAINER_PREFIX')}core:${getPreset('MORIO_CORE_PORT')}`,
+  `http://${getPreset('MORIO_CONTAINER_PREFIX')}core.internal:${getPreset('MORIO_CORE_PORT')}`,
   coreErrorHandler
 )
 
@@ -645,7 +645,7 @@ utils.sendErrorResponse = (res, template, url = false, extraData = {}) => {
    * Add the instance
    */
   data.instance =
-    `http://${getPreset('MORIO_CONTAINER_PREFIX')}api:${utils.getPreset('MORIO_API_PORT')}` +
+    `http://${getPreset('MORIO_CONTAINER_PREFIX')}api.internal:${utils.getPreset('MORIO_API_PORT')}` +
     (data.route ? data.route : url ? url : '')
 
   return res

--- a/core/src/lib/cluster.mjs
+++ b/core/src/lib/cluster.mjs
@@ -600,10 +600,15 @@ export async function ensureMorioCluster() {
       {
         Aliases: [
           `${utils.getPreset('MORIO_CONTAINER_PREFIX')}core`,
+          `${utils.getPreset('MORIO_CONTAINER_PREFIX')}core.internal`,
           `${utils.getPreset('MORIO_CONTAINER_PREFIX')}coredocs`,
-          utils.isEphemeral()
-            ? `${utils.getPreset('MORIO_CONTAINER_PREFIX')}core_ephemeral`
-            : `${utils.getPreset('MORIO_CONTAINER_PREFIX')}core_${utils.getNodeSerial()}`,
+          `${utils.getPreset('MORIO_CONTAINER_PREFIX')}coredocs.internal`,
+          ...(utils.isEphemeral()
+            ? [`${utils.getPreset('MORIO_CONTAINER_PREFIX')}core_ephemeral`]
+            : [
+                `${utils.getPreset('MORIO_CONTAINER_PREFIX')}core_${utils.getNodeSerial()}`,
+                `${utils.getPreset('MORIO_CONTAINER_PREFIX')}core_${utils.getNodeSerial()}.internal`,
+              ]),
         ],
       } // Endpoint config
     )

--- a/core/src/lib/docker.mjs
+++ b/core/src/lib/docker.mjs
@@ -254,7 +254,13 @@ export function generateContainerConfig(serviceName) {
     },
   }
   opts.NetworkingConfig.EndpointsConfig[utils.getNetworkName()] = {
-    Aliases: [name, `${name}_${utils.getNodeSerial() || 1}`, ...aliases],
+    Aliases: [
+      name,
+      `${name}.internal`,
+      `${name}_${utils.getNodeSerial() || 1}`,
+      `${name}_${utils.getNodeSerial() || 1}.internal`,
+      ...aliases,
+    ],
   }
 
   /*

--- a/core/src/lib/services/api.mjs
+++ b/core/src/lib/services/api.mjs
@@ -71,7 +71,7 @@ export async function reloadApi() {
 
 const isApiUp = async (reload = false) => {
   const status = await testUrl(
-    `http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}api:${utils.getPreset('MORIO_API_PORT')}/${reload ? 'reload' : 'up'}`,
+    `http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}api.internal:${utils.getPreset('MORIO_API_PORT')}/${reload ? 'reload' : 'up'}`,
     {
       returnAs: 'status',
     }

--- a/core/src/lib/services/ca.mjs
+++ b/core/src/lib/services/ca.mjs
@@ -20,7 +20,7 @@ export const service = {
      */
     heartbeat: async () => {
       const result = await testUrl(
-        `https://${utils.getPreset('MORIO_CONTAINER_PREFIX')}ca:${utils.getPreset('MORIO_CA_PORT')}/health`,
+        `https://${utils.getPreset('MORIO_CONTAINER_PREFIX')}ca.internal:${utils.getPreset('MORIO_CA_PORT')}/health`,
         {
           returnAs: 'json',
           ignoreCertificate: true,
@@ -117,7 +117,7 @@ export const service = {
  */
 export async function isCaUp() {
   const result = await testUrl(
-    `https://${utils.getPreset('MORIO_CONTAINER_PREFIX')}ca:${utils.getPreset('MORIO_CA_PORT')}/health`,
+    `https://${utils.getPreset('MORIO_CONTAINER_PREFIX')}ca.internal:${utils.getPreset('MORIO_CA_PORT')}/health`,
     {
       ignoreCertificate: true,
       returnAs: 'json',
@@ -167,7 +167,7 @@ async function reloadCaConfiguration() {
    * Save fingerprint, JWK, and root certificate in memory for easy access
    */
   utils.setCaConfig({
-    url: `https://${utils.getPreset('MORIO_CONTAINER_PREFIX')}ca:${utils.getPreset('MORIO_CA_PORT')}`,
+    url: `https://${utils.getPreset('MORIO_CONTAINER_PREFIX')}ca.internal:${utils.getPreset('MORIO_CA_PORT')}`,
     fingerprint: caDefaults.fingerprint,
     jwk,
     certificate,
@@ -198,7 +198,7 @@ export async function generateCaConfig(keys = {}, custom = {}) {
      * Save root certificate and fingerprint in memory
      */
     utils.setCaConfig({
-      url: `https://${utils.getPreset('MORIO_CONTAINER_PREFIX')}ca:${utils.getPreset('MORIO_CA_PORT')}`,
+      url: `https://${utils.getPreset('MORIO_CONTAINER_PREFIX')}ca.internal:${utils.getPreset('MORIO_CA_PORT')}`,
       fingerprint: keys.rfpr,
       jwk: keys.jwk,
       certificate: keys.rcrt,
@@ -244,7 +244,7 @@ export async function generateCaConfig(keys = {}, custom = {}) {
      * Save root certificate and fingerprint in memory
      */
     utils.setCaConfig({
-      url: `https://${utils.getPreset('MORIO_CONTAINER_PREFIX')}ca:${utils.getPreset('MORIO_CA_PORT')}`,
+      url: `https://${utils.getPreset('MORIO_CONTAINER_PREFIX')}ca.internal:${utils.getPreset('MORIO_CA_PORT')}`,
       fingerprint: init.root.fingerprint,
       jwk,
       certificate: init.root.certificate,
@@ -264,7 +264,7 @@ export async function ensureCaConfig(withKeys = false) {
    */
   const keys = withKeys ? withKeys : utils.getKeys()
   utils.setCaConfig({
-    url: `https://${utils.getPreset('MORIO_CONTAINER_PREFIX')}ca:${utils.getPreset('MORIO_CA_PORT')}`,
+    url: `https://${utils.getPreset('MORIO_CONTAINER_PREFIX')}ca.internal:${utils.getPreset('MORIO_CA_PORT')}`,
     fingerprint: keys.rfpr,
     jwk: keys.jwk,
     certificate: keys.rcrt,

--- a/core/src/lib/services/console.mjs
+++ b/core/src/lib/services/console.mjs
@@ -17,7 +17,7 @@ export const service = {
      */
     heartbeat: async () => {
       const result = await testUrl(
-        `http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}console:${utils.getPreset('MORIO_CONSOLE_PORT')}/console/api/brokers`,
+        `http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}console.internal:${utils.getPreset('MORIO_CONSOLE_PORT')}/console/api/brokers`,
         { returnAs: 'json', timeout: 12000 }
       )
       const status = Array.isArray(result) && result.length > 0 && result[0].brokerId ? 0 : 1

--- a/core/src/lib/services/db.mjs
+++ b/core/src/lib/services/db.mjs
@@ -16,7 +16,7 @@ export const service = {
      */
     heartbeat: async () => {
       const result = await testUrl(
-        `http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}db:${utils.getPreset('MORIO_DB_HTTP_PORT')}/readyz`,
+        `http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}db.internal:${utils.getPreset('MORIO_DB_HTTP_PORT')}/readyz`,
         {
           returnAs: 'json',
         }
@@ -106,7 +106,7 @@ async function ensureLocalPrerequisites() {
  */
 export async function isDbUp() {
   const result = await testUrl(
-    `http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}db:${utils.getPreset('MORIO_DB_HTTP_PORT')}/readyz`,
+    `http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}db.internal:${utils.getPreset('MORIO_DB_HTTP_PORT')}/readyz`,
     {
       ignoreCertificate: true,
       // This endpoint does not return JSON

--- a/core/src/lib/services/eda.mjs
+++ b/core/src/lib/services/eda.mjs
@@ -110,7 +110,7 @@ async function ensureLocalPrerequisites() {
      * is tell it what kind of a node we are on, it's FQDN and the cluster FQDN.
      */
     const settings = {
-      api: `http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}api:${utils.getPreset('MORIO_API_PORT')}`,
+      api: `http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}api.internal:${utils.getPreset('MORIO_API_PORT')}`,
       broker: {
         brokers: utils
           .getBrokerFqdns()
@@ -125,7 +125,7 @@ async function ensureLocalPrerequisites() {
         },
       },
       db: {
-        local: `http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}db:${utils.getPreset('MORIO_DB_HTTP_PORT')}`,
+        local: `http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}db.internal:${utils.getPreset('MORIO_DB_HTTP_PORT')}`,
         ccdb: `https://${utils.getNodeFqdn()}:${utils.getPreset('MORIO_DB_PROXY_PORT')}`,
         connection: utils.isBrokerNode() ? 'local' : 'ccdb',
         tablePrefix: utils.getPreset('MORIO_EDA_TABLE_PREFIX'),

--- a/core/src/lib/services/proxy.mjs
+++ b/core/src/lib/services/proxy.mjs
@@ -18,7 +18,7 @@ export const service = {
      */
     heartbeat: async () => {
       const result = await testUrl(
-        `https://${utils.getPreset('MORIO_CONTAINER_PREFIX')}proxy/api/overview`,
+        `https://${utils.getPreset('MORIO_CONTAINER_PREFIX')}proxy.internal/api/overview`,
         {
           returnAs: 'json',
           ignoreCertificate: true,

--- a/core/src/lib/tls.mjs
+++ b/core/src/lib/tls.mjs
@@ -94,7 +94,7 @@ export async function createX509Certificate(data) {
       sub: config.cn,
       iat: Math.floor(Date.now() / 1000) - 1,
       iss: 'admin',
-      aud: `https://${utils.getPreset('MORIO_CONTAINER_PREFIX')}ca:${utils.getPreset('MORIO_CA_PORT')}/1.0/sign`,
+      aud: `https://${utils.getPreset('MORIO_CONTAINER_PREFIX')}ca.internal:${utils.getPreset('MORIO_CA_PORT')}/1.0/sign`,
       nbf: Math.floor(Date.now() / 1000) - 1,
       exp: Number(Date.now()) + 300000,
     },
@@ -113,7 +113,7 @@ export async function createX509Certificate(data) {
   let result
   try {
     result = await axios.post(
-      `https://${utils.getPreset('MORIO_CONTAINER_PREFIX')}ca:${utils.getPreset('MORIO_CA_PORT')}/1.0/sign`,
+      `https://${utils.getPreset('MORIO_CONTAINER_PREFIX')}ca.internal:${utils.getPreset('MORIO_CA_PORT')}/1.0/sign`,
       {
         csr: csr.csr,
         ott: jwt,

--- a/core/src/lib/utils.mjs
+++ b/core/src/lib/utils.mjs
@@ -1297,7 +1297,7 @@ utils.resetServicesStateAge = () => {
  * Returns a pre-configured API client, itself an object
  */
 utils.apiClient = restClient(
-  `http://${getPreset('MORIO_CONTAINER_PREFIX')}api:${getPreset('MORIO_API_PORT')}`,
+  `http://${getPreset('MORIO_CONTAINER_PREFIX')}api.internal:${getPreset('MORIO_API_PORT')}`,
   ({ options, err }) => {
     log.warn(
       {
@@ -1355,7 +1355,7 @@ utils.sendErrorResponse = (res, template, url = false, extraData = {}) => {
    * Add the instance
    */
   data.instance =
-    `http://${getPreset('MORIO_CONTAINER_PREFIX')}core:${utils.getPreset('MORIO_CORE_PORT')}` +
+    `http://${getPreset('MORIO_CONTAINER_PREFIX')}core.internal:${utils.getPreset('MORIO_CORE_PORT')}` +
     (data.route ? data.route : url ? url : '')
 
   return res

--- a/scripts/reconfigure.mjs
+++ b/scripts/reconfigure.mjs
@@ -1,4 +1,4 @@
-import { writeFile } from '@itsmorio/shared/fs'
+import { readFile, writeFile } from '@itsmorio/shared/fs'
 import { resolveServiceConfiguration, getPreset } from '@itsmorio/config'
 import { pullConfig } from '@itsmorio/config'
 import { Store } from '@itsmorio/shared/store'
@@ -68,6 +68,7 @@ const getHelpers = (env) => {
   return { store, utils }
 }
 
+
 const config = {
   core: {
     /*
@@ -94,10 +95,28 @@ const config = {
 /*
  * Generate run files for development
  */
-const cliOptions = (name, env) => `\\
+const cliOptions = async (name, env) => {
+  /*
+   * The local/clioptions.dev file can be used to add extra
+   * docker cli options. For example, to configure a proxy
+   */
+  let extraCliOptions = ''
+  if (env === 'dev') {
+    try {
+      const extra = await readFile('./local/clioptions.dev')
+      if (extra) extraCliOptions = extra
+      else console.log('No lolca/clioptions.dev file found')
+    }
+    catch(err) {
+      console.log('Error reading local/clioptions.dev', err)
+    }
+  }
+
+  return `\\
   ${env === 'test' ? '--interactive --rm' : '-d'} \\
   --user root \\
   --name=morio-${config[name][env].container.container_name} \\
+  --network-alias=morio-${config[name][env].container.container_name}.internal \\
   --hostname=morio-${config[name][env].container.container_name} \\
   --label morio.service=${name} \\
   --log-driver=${MORIO_DOCKER_LOG_DRIVER} \\
@@ -119,11 +138,13 @@ ${(config[name][env].container?.labels || []).map((lab) => `  -l "${lab.split('`
   -e GITHUB_PR_NUMBER=${process.env['GITHUB_PR_NUMBER']} \\
   -e CODECOV_TOKEN=${process.env['CODECOV_TOKEN']} \\
   -e NODE_ENV=${presetGetters[env]('NODE_ENV')} \\
+  ${extraCliOptions.trim()} \
 ${MORIO_DOCKER_ADD_HOST ? '-e MORIO_DOCKER_ADD_HOST="' + MORIO_DOCKER_ADD_HOST + '"' : ''} \\
   ${
     env !== 'prod' ? '-e MORIO_GIT_ROOT=' + MORIO_GIT_ROOT + ' \\\n  ' : ''
   }${config[name][env].container.image}:${env === 'prod' ? 'v' + pkg.version : 'dev'} ${env === 'test' ? 'bash /morio/' + name + '/tests/run-unit-tests.sh' : ''}
-`
+  `
+}
 
 const preApiTest = `
 #
@@ -178,7 +199,7 @@ if [ -z "\${MORIO_FQDN}" ]; then
 fi
 `
 
-const script = (name, env) => `#!/bin/bash
+const script = async (name, env) => `#!/bin/bash
 #
 # This file is auto-generated
 #
@@ -189,13 +210,15 @@ ${name === 'core' && env === 'test' ? testFqdnCheck : ''}
 ${name === 'api' && env === 'test' ? testFqdnCheck : ''}
 ${name === 'api' ? preApiTest : ''}
 
-docker run ${cliOptions(name, env)}
+docker run ${(await cliOptions(name, env))}
 ${name === 'api' ? postApiTest : ''}
 `
 for (const env of ['dev', 'test', 'prod']) {
-  await writeFile(`core/run-${env}-container.sh`, script('core', env), false, 0o755)
+  const content = await script('core', env)
+  await writeFile(`core/run-${env}-container.sh`, content, false, 0o755)
 }
-await writeFile(`api/run-test-container.sh`, script('api', 'test'), false, 0o755)
+const content = await script('core', 'test')
+await writeFile(`api/run-test-container.sh`, content, false, 0o755)
 
 await writeFile(`VERSION`, pkg.version)
 


### PR DESCRIPTION
This is a matter of convenience to make it easier to configure Morio in an environment that requires a proxy to access the internet.

When core needs to preseed settings, it can be setup with a proxy by changing the sytemd unit file. However, once a proxy is configured, we still need to avoid that inter-container connections go via the proxy.

Here, we add an [name].internal network alias to all containers and we use this when connecting internally (eg: core would connect to api.internal). This way, you can add '.internal' to your NO_PROXY environment variable and things should _just work_.