### PR TITLE
[watcher] fix: Incorrect monitor and .internal TLD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [ui] Improved flags UI in the settings wizard
 - [ui] Do not show OIDC role selection if only 1 role is available
 - [watcher] Upgraded Elastic Heartbeat from 8.16.5 to 8.17.4
+- [watcher] Pre-configured monitors use .internal TLS to avoid proxy issues
 
 ### Fixed
 

--- a/config/monitors.mjs
+++ b/config/monitors.mjs
@@ -26,7 +26,7 @@ export function monitors(utils) {
       type: 'http',
       name: `Morio API Service: API on ${utils.getNodeFqdn()}`,
       urls: [
-        `http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}api:${utils.getPreset('MORIO_API_PORT')}/status`,
+        `http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}api.internal:${utils.getPreset('MORIO_API_PORT')}/status`,
       ],
       check: {
         response: { status: [200] },
@@ -42,7 +42,7 @@ export function monitors(utils) {
       type: 'http',
       name: `Morio CA API on ${utils.getNodeFqdn()}`,
       urls: [
-        `https://${utils.getPreset('MORIO_CONTAINER_PREFIX')}ca:${utils.getPreset('MORIO_CA_PORT')}/health#MORIO_IGNORE_CERTIFICATE_EXPIRY`,
+        `https://${utils.getPreset('MORIO_CONTAINER_PREFIX')}ca.internal:${utils.getPreset('MORIO_CA_PORT')}/health#MORIO_IGNORE_CERTIFICATE_EXPIRY`,
       ],
       check: {
         request: { method: 'GET' },
@@ -61,7 +61,7 @@ export function monitors(utils) {
       type: 'http',
       name: `Morio Core Service: API on ${utils.getNodeFqdn()}`,
       urls: [
-        `http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}core:${utils.getPreset('MORIO_CORE_PORT')}/status`,
+        `http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}core.internal:${utils.getPreset('MORIO_CORE_PORT')}/status`,
       ],
       check: {
         response: {
@@ -92,14 +92,14 @@ export function monitors(utils) {
     ui: utils.getFlag('DISABLE_SERVICE_UI', false) ? undefined : {
       ...imd,
       type: 'http',
-      name: `Morio DB Service: API on ${utils.getNodeFqdn()}`,
+      name: `Morio UI Service: UI on ${utils.getNodeFqdn()}`,
       urls: [
-        `http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}db:${utils.getPreset('MORIO_DB_HTTP_PORT')}/readyz?noleader`,
+        `http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}ui.internal:${utils.getPreset('MORIO_UI_PORT')}/favicon.svg`,
       ],
       check: {
         response: {
           status: [200],
-          body: ['node ok'],
+          body: ['viewBox'],
         },
       },
       id: `morio.${cluster}.internal.ui`,
@@ -112,7 +112,7 @@ export function monitors(utils) {
       type: 'http',
       name: `Morio Watcher Service: HTTP metrics on ${utils.getNodeFqdn()}`,
       urls: [
-        `http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}watcher:${utils.getPreset('MORIO_WATCHER_HTTP_PORT')}/`,
+        `http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}watcher.internal:${utils.getPreset('MORIO_WATCHER_HTTP_PORT')}/`,
       ],
       check: {
         response: {
@@ -134,7 +134,7 @@ export function monitors(utils) {
       type: 'http',
       name: `Morio Broker Service: Admin API on ${utils.getNodeFqdn()}`,
       urls: [
-        `http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}broker:${utils.getPreset('MORIO_BROKER_ADMIN_API_PORT')}/`,
+        `http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}broker.internal:${utils.getPreset('MORIO_BROKER_ADMIN_API_PORT')}/`,
       ],
       check: {
         response: { status: [404] },
@@ -162,7 +162,7 @@ export function monitors(utils) {
       type: 'http',
       name: `Morio Broker Service: REST API on ${utils.getNodeFqdn()}`,
       urls: [
-        `http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}broker:${utils.getPreset('MORIO_BROKER_REST_API_PORT')}/`,
+        `http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}broker.internal:${utils.getPreset('MORIO_BROKER_REST_API_PORT')}/`,
       ],
       check: {
         response: { status: [404] },
@@ -177,7 +177,7 @@ export function monitors(utils) {
       type: 'http',
       name: `Morio Console Service: UI on ${utils.getNodeFqdn()}`,
       urls: [
-        `http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}console:${utils.getPreset('MORIO_CONSOLE_PORT')}/console/favicon-32.png`,
+        `http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}console.internal:${utils.getPreset('MORIO_CONSOLE_PORT')}/console/favicon-32.png`,
       ],
       check: {
         response: {
@@ -194,7 +194,7 @@ export function monitors(utils) {
       type: 'http',
       name: `Morio DB Service: API on ${utils.getNodeFqdn()}`,
       urls: [
-        `http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}db:${utils.getPreset('MORIO_DB_HTTP_PORT')}/readyz?noleader`,
+        `http://${utils.getPreset('MORIO_CONTAINER_PREFIX')}db.internal:${utils.getPreset('MORIO_DB_HTTP_PORT')}/readyz?noleader`,
       ],
       check: {
         response: {


### PR DESCRIPTION
Switched to using the `.internal` TLD for deployments that have a proxy server configured, ensuring it is easy to avoid using the proxy for internal docker traffic.

Also fixes an incorrect healthcheck for the UI service.